### PR TITLE
Fix vehicle-service JWT auth

### DIFF
--- a/packages/vehicle-service/src/__tests__/middleware/auth.middleware.test.ts
+++ b/packages/vehicle-service/src/__tests__/middleware/auth.middleware.test.ts
@@ -1,0 +1,33 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { authMiddleware } from '../../middleware/auth.middleware';
+
+const app = express();
+app.get('/test', authMiddleware, (_: Request, res: Response) => {
+  res.status(200).json({ ok: true });
+});
+
+describe('authMiddleware', () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = 'test-secret';
+  });
+
+  it('allows requests with valid token', async () => {
+    const token = jwt.sign({ id: 'user1' }, process.env.JWT_SECRET as string);
+    const res = await request(app)
+      .get('/test')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('rejects requests with invalid token', async () => {
+    const res = await request(app)
+      .get('/test')
+      .set('Authorization', 'Bearer invalid');
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/vehicle-service/src/middleware/auth.middleware.ts
+++ b/packages/vehicle-service/src/middleware/auth.middleware.ts
@@ -1,4 +1,13 @@
 import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: unknown;
+    }
+  }
+}
 
 export const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
   const authHeader = req.headers.authorization;
@@ -14,10 +23,11 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
   }
 
   try {
-    // TODO: Implement actual token verification
-    // For now, just pass through
+    const secret = process.env.JWT_SECRET || 'your-secret-key';
+    const decoded = jwt.verify(token, secret);
+    req.user = decoded;
     next();
   } catch (error) {
     return res.status(401).json({ message: 'Invalid token' });
   }
-}; 
+};


### PR DESCRIPTION
## Summary
- implement JWT token verification for vehicle-service middleware
- add tests for auth middleware

## Testing
- `npx lerna run test --scope vehicle-service` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lerna)*

------
https://chatgpt.com/codex/tasks/task_e_6840bcf4c9a88333950567d7472c60c5