### PR TITLE
Fix pnpm missing in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,12 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '18'
           cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
           
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -37,7 +43,13 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
-          
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         


### PR DESCRIPTION
## Summary
- install pnpm in the GitHub Actions workflow

## Testing
- `pnpm lint` *(fails: lerna not found)*
- `pnpm test` *(fails: lerna not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417a43d4b88333b42d0e11ace7fe3e