### PR TITLE
Remove unused api-gateway submodule and add docs

### DIFF
--- a/packages/api-gateway/README.md
+++ b/packages/api-gateway/README.md
@@ -1,0 +1,7 @@
+# API Gateway
+
+This directory currently contains documentation for the planned API Gateway service.
+
+The gateway will route external requests to internal services, provide authentication, and serve as a central point for monitoring.
+
+Implementation is not yet available. Further details will be added as development progresses.


### PR DESCRIPTION
## Summary
- remove leftover api-gateway submodule
- add placeholder README for planned API Gateway service

## Testing
- `pnpm test` *(fails: lerna not found)*
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*

------
https://chatgpt.com/codex/tasks/task_e_68417af42cc0833381b5056a62bac780