### PR TITLE
Add Prisma schemas and update service docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,29 @@ docker build -t vehicle-service .
 docker run -p 3000:3000 vehicle-service
 ```
 
+### driver-service
+
+```bash
+cd packages/driver-service
+pnpm install
+pnpm prisma:generate
+pnpm prisma:migrate
+pnpm dev
+```
+
+### system-notification-service
+
+```bash
+cd packages/system-notification-service
+pnpm install
+pnpm prisma:generate
+pnpm prisma:migrate
+pnpm dev
+```
+
 ### Other Services
 
-`driver-service`, `student-service`, `document-service` and `system-notification-service` follow the same pattern:
+`student-service` and `document-service` follow the same basic pattern:
 
 ```bash
 pnpm install

--- a/packages/driver-service/README.md
+++ b/packages/driver-service/README.md
@@ -1,0 +1,19 @@
+# Driver Service
+
+This service manages driver data and publishes driver events.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pnpm install
+   ```
+2. Generate the Prisma client and run migrations:
+   ```bash
+   pnpm prisma:generate
+   pnpm prisma:migrate
+   ```
+3. Start the development server:
+   ```bash
+   pnpm dev
+   ```

--- a/packages/driver-service/prisma/schema.prisma
+++ b/packages/driver-service/prisma/schema.prisma
@@ -1,0 +1,76 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum DriverStatus {
+  ACTIVE
+  INACTIVE
+  ASSIGNED
+  ON_LEAVE
+}
+
+enum RunStatus {
+  PENDING
+  IN_PROGRESS
+  COMPLETED
+  CANCELLED
+}
+
+enum RunType {
+  REGULAR
+  SPECIAL
+  EMERGENCY
+}
+
+model Driver {
+  id                String   @id @default(uuid())
+  callNumber        String
+  pdaPassword       String
+  firstName         String
+  lastName          String
+  gender            String
+  dateOfBirth       DateTime
+  addressLine1      String
+  addressLine2      String?
+  postcode          String
+  phoneNumber       String
+  email             String   @unique
+  licenseNumber     String
+  licenseExpiryDate DateTime
+  dbsNumber         String
+  dbsExpiryDate     DateTime
+  medicalExpiryDate DateTime
+  rentalExpiryDate  DateTime
+  status            DriverStatus @default(ACTIVE)
+  currentRunId      String?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  runs Run[] @relation("DriverRuns")
+}
+
+model Run {
+  id                 String    @id @default(uuid())
+  type               RunType
+  status             RunStatus @default(PENDING)
+  startTime          DateTime
+  endTime            DateTime?
+  pickupLocation     Json
+  dropoffLocation    Json
+  driverId           String?
+  studentIds         Json
+  routeId            String?
+  notes              String?
+  scheduledStartTime DateTime?
+  actualStartTime    DateTime?
+  rating             Int?
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+
+  driver Driver? @relation("DriverRuns", fields: [driverId], references: [id])
+}

--- a/packages/run-service/prisma/schema.prisma
+++ b/packages/run-service/prisma/schema.prisma
@@ -1,0 +1,53 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum RunStatus {
+  PENDING
+  IN_PROGRESS
+  COMPLETED
+  CANCELLED
+}
+
+enum RunType {
+  REGULAR
+  SPECIAL
+  EMERGENCY
+}
+
+enum ScheduleType {
+  ONE_TIME
+  DAILY
+  WEEKLY
+  CUSTOM
+}
+
+model Run {
+  id                 String        @id @default(uuid())
+  type               RunType
+  status             RunStatus     @default(PENDING)
+  startTime          DateTime
+  endTime            DateTime?
+  pickupLocation     Json
+  dropoffLocation    Json
+  driverId           String?
+  paId               String?
+  studentIds         Json
+  routeId            String?
+  notes              String?
+  scheduleType       ScheduleType
+  recurrenceRule     String?
+  endDate            DateTime?
+  lastOccurrence     DateTime?
+  nextOccurrence     DateTime?
+  scheduledStartTime DateTime?
+  actualStartTime    DateTime?
+  rating             Int?
+  createdAt          DateTime       @default(now())
+  updatedAt          DateTime       @updatedAt
+}

--- a/packages/system-notification-service/README.md
+++ b/packages/system-notification-service/README.md
@@ -1,0 +1,19 @@
+# System Notification Service
+
+Handles sending notifications via push, in-app, SMS and email.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pnpm install
+   ```
+2. Generate the Prisma client and run migrations:
+   ```bash
+   pnpm prisma:generate
+   pnpm prisma:migrate
+   ```
+3. Start the development server:
+   ```bash
+   pnpm dev
+   ```

--- a/packages/system-notification-service/prisma/schema.prisma
+++ b/packages/system-notification-service/prisma/schema.prisma
@@ -1,0 +1,65 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum NotificationChannel {
+  PUSH
+  IN_APP
+  SMS
+  EMAIL
+}
+
+enum NotificationPriority {
+  LOW
+  MEDIUM
+  HIGH
+  URGENT
+}
+
+enum NotificationStatus {
+  PENDING
+  SENT
+  FAILED
+  DELIVERED
+  READ
+}
+
+model Notification {
+  id        String               @id @default(uuid())
+  userId    String
+  title     String
+  message   String
+  channel   NotificationChannel
+  priority  NotificationPriority
+  status    NotificationStatus   @default(PENDING)
+  metadata  Json?
+  createdAt DateTime             @default(now())
+  updatedAt DateTime             @updatedAt
+}
+
+model NotificationPreferences {
+  userId      String   @id
+  pushEnabled Boolean
+  inAppEnabled Boolean
+  smsEnabled  Boolean
+  emailEnabled Boolean
+  quietHours  Json?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+model NotificationTemplate {
+  id        String               @id @default(uuid())
+  name      String               @unique
+  title     String
+  message   String
+  channel   NotificationChannel
+  variables Json
+  createdAt DateTime             @default(now())
+  updatedAt DateTime             @updatedAt
+}


### PR DESCRIPTION
## Summary
- add Prisma schemas for driver-service, run-service and system-notification-service
- document Prisma usage for driver-service and system-notification-service
- update root README with instructions for new Prisma-enabled services

## Testing
- `pnpm test` *(fails: lerna not found or dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68417afe1fbc8333b6f17e8096dcc75a