### PR TITLE
Implement compliance rule evaluation

### DIFF
--- a/packages/document-service/src/__tests__/services/compliance.evaluation.test.ts
+++ b/packages/document-service/src/__tests__/services/compliance.evaluation.test.ts
@@ -1,0 +1,88 @@
+import { DocumentService } from '../../services/document.service';
+import { PrismaClient } from '@prisma/client';
+import { S3 } from 'aws-sdk';
+import { createWorker } from 'tesseract.js';
+import { RabbitMQService } from '@shared/messaging/rabbitmq.service';
+import { Logger } from 'winston';
+
+jest.mock('@prisma/client', () => {
+  const mockPrisma = {
+    $transaction: jest.fn(),
+    document: {},
+    documentVersion: {},
+    documentAccess: {},
+    oCRResult: {},
+    complianceRule: {}
+  };
+  return {
+    PrismaClient: jest.fn(() => mockPrisma),
+    Prisma: { JsonObject: {} }
+  };
+});
+
+jest.mock('aws-sdk', () => {
+  const mockS3 = {
+    putObject: jest.fn().mockReturnThis(),
+    getObject: jest.fn().mockReturnThis(),
+    promise: jest.fn()
+  };
+  return {
+    S3: jest.fn(() => mockS3)
+  };
+});
+
+jest.mock('tesseract.js', () => ({ createWorker: jest.fn() }));
+
+jest.mock('@shared/messaging/rabbitmq.service', () => ({
+  RabbitMQService: jest.fn().mockImplementation(() => ({ publishMessage: jest.fn() }))
+}));
+
+jest.mock('winston', () => ({
+  Logger: jest.fn().mockImplementation(() => ({ info: jest.fn(), error: jest.fn() }))
+}));
+
+describe('evaluateComplianceRule', () => {
+  let service: DocumentService;
+  let mockPrisma: any;
+  let mockS3: any;
+  let mockRabbitMQ: any;
+  let mockLogger: any;
+
+  beforeEach(() => {
+    mockPrisma = new PrismaClient();
+    mockS3 = new S3();
+    mockRabbitMQ = new RabbitMQService({ url: '', exchange: '', queue: '' }, new Logger());
+    mockLogger = new Logger();
+    service = new DocumentService(mockPrisma, mockRabbitMQ, mockLogger);
+    (service as any).s3 = mockS3;
+  });
+
+  it('returns true when all conditions pass', async () => {
+    const document = {
+      metadata: { amount: 100, status: 'PAID' }
+    };
+    const rule = {
+      conditions: [
+        { field: 'metadata.status', operator: 'eq', value: 'PAID' },
+        { field: 'metadata.amount', operator: 'gte', value: 50 }
+      ]
+    };
+
+    const result = await (service as any).evaluateComplianceRule(document, rule);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when any condition fails', async () => {
+    const document = {
+      metadata: { amount: 30, status: 'PAID' }
+    };
+    const rule = {
+      conditions: [
+        { field: 'metadata.amount', operator: 'gte', value: 50 }
+      ]
+    };
+
+    const result = await (service as any).evaluateComplianceRule(document, rule);
+    expect(result).toBe(false);
+  });
+});

--- a/packages/document-service/src/services/document.service.ts
+++ b/packages/document-service/src/services/document.service.ts
@@ -306,9 +306,52 @@ export class DocumentService {
   }
 
   private async evaluateComplianceRule(document: any, rule: any): Promise<boolean> {
-    // Implement compliance rule evaluation logic based on conditions
-    const conditions = rule.conditions as Record<string, any>;
-    // This is a placeholder - implement based on your specific compliance requirements
+    const conditions = (rule.conditions || []) as {
+      field: string;
+      operator: string;
+      value: any;
+    }[];
+
+    for (const condition of conditions) {
+      const { field, operator, value } = condition;
+      const actual = field.split('.').reduce((obj: any, key: string) => obj?.[key], document);
+
+      switch (operator) {
+        case 'eq':
+          if (actual !== value) return false;
+          break;
+        case 'neq':
+          if (actual === value) return false;
+          break;
+        case 'gt':
+          if (!(actual > value)) return false;
+          break;
+        case 'gte':
+          if (!(actual >= value)) return false;
+          break;
+        case 'lt':
+          if (!(actual < value)) return false;
+          break;
+        case 'lte':
+          if (!(actual <= value)) return false;
+          break;
+        case 'contains':
+          if (typeof actual === 'string' && typeof value === 'string') {
+            if (!actual.includes(value)) return false;
+          } else if (Array.isArray(actual)) {
+            if (!actual.includes(value)) return false;
+          } else {
+            return false;
+          }
+          break;
+        case 'exists':
+          if (actual === undefined || actual === null) return false;
+          break;
+        default:
+          return false;
+      }
+    }
+
     return true;
   }
 


### PR DESCRIPTION
## Summary
- add evaluation logic for compliance rule conditions
- test compliance rule evaluation for passing and failing cases

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Fexpress: Forbidden - 403)*
- `pnpm test --filter document-service` *(fails: sh: 1: lerna: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417ada7f8083338e67029dfc8fad41