### PR TITLE
Fix shared test script

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/index.js",
     "dev": "nodemon src/index.ts",
     "build": "tsc",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "lint": "eslint src/**/*.ts",
     "format": "prettier --write \"src/**/*.ts\"",
     "prisma:generate": "prisma generate",


### PR DESCRIPTION
## Summary
- update the `shared` package test script to not fail when no tests are present

## Testing
- `pnpm run test` *(fails: `lerna` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417b862fe48333884272699a4bb405