### PR TITLE
Fix pnpm lockfile error in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
           run_install: false
 
       - name: Setup Node.js
@@ -41,7 +41,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
           run_install: false
 
       - name: Setup Node.js


### PR DESCRIPTION
## Summary
- use pnpm `version: 9` in CI workflow so the lockfile can be read

## Testing
- `pnpm install --frozen-lockfile` *(fails: GET https://registry.npmjs.org/lerna/-/lerna-6.6.2.tgz: Forbidden)*
- `pnpm workspace @send/api-gateway test` *(fails: Command "workspace" not found)*


------
https://chatgpt.com/codex/tasks/task_e_6841848d71dc83339ace41fa36191886