### PR TITLE
Add tsconfigs for missing services

### DIFF
--- a/packages/student-service/tsconfig.json
+++ b/packages/student-service/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": ".",
+    "paths": {
+      "@services/*": ["./src/services/*"],
+      "@types/*": ["./src/types/*"],
+      "@shared/*": ["../shared/src/*"]
+    },
+    "types": ["node", "jest", "express"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "references": [
+    { "path": "../shared" }
+  ]
+}

--- a/packages/tracking-service/tsconfig.json
+++ b/packages/tracking-service/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": ".",
+    "paths": {
+      "@services/*": ["./src/services/*"],
+      "@types/*": ["./src/types/*"],
+      "@shared/*": ["../shared/src/*"]
+    },
+    "types": ["node", "jest", "express"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "references": [
+    { "path": "../shared" }
+  ]
+}

--- a/packages/user-service/tsconfig.json
+++ b/packages/user-service/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": ".",
+    "paths": {
+      "@services/*": ["./src/services/*"],
+      "@types/*": ["./src/types/*"],
+      "@shared/*": ["../shared/src/*"]
+    },
+    "types": ["node", "jest", "express"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "references": [
+    { "path": "../shared" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `tsconfig.json` to user-service, tracking-service, and student-service
- map local services, types, and shared aliases
- reference shared project
- fix `rootDir` paths in service configs

## Testing
- `pnpm install`
- `npx tsc -p packages/user-service/tsconfig.json --noEmit` *(fails: cannot find modules)*
- `npx tsc -p packages/tracking-service/tsconfig.json --noEmit` *(fails: cannot find modules)*
- `npx tsc -p packages/student-service/tsconfig.json --noEmit` *(fails: cannot find modules)*


------
https://chatgpt.com/codex/tasks/task_e_684184bad9bc83338fd69e35c71acd38