### PR TITLE
Fix pnpm version and commands in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
           run_install: false
 
       - name: Setup Node.js
@@ -28,7 +28,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: pnpm workspace @send/api-gateway test
+        run: pnpm test
         env:
           NODE_ENV: test
 
@@ -41,7 +41,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
           run_install: false
 
       - name: Setup Node.js
@@ -54,7 +54,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: pnpm workspace @send/api-gateway build
+        run: pnpm build
 
       - name: Build Docker image
         run: docker build -t api-gateway:latest -f packages/api-gateway/Dockerfile .


### PR DESCRIPTION
## Summary
- use pnpm `version: 9` in workflow so the lockfile is compatible
- run repository-wide test/build commands instead of a missing workspace

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm test` *(fails: tasks failed in several packages)*
- `pnpm build` *(fails: build tasks failed)*

------
https://chatgpt.com/codex/tasks/task_e_6841848d71dc83339ace41fa36191886