### PR TITLE
Fix shared import mapping

### DIFF
--- a/packages/run-service/jest.config.js
+++ b/packages/run-service/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   },
   moduleNameMapper: {
     '^@send/shared$': '<rootDir>/../../shared/src',
+    '^@send/shared/(.*)$': '<rootDir>/../../shared/src/$1',
   },
   setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup.ts'],
   coverageDirectory: 'coverage',

--- a/packages/system-notification-service/jest.config.js
+++ b/packages/system-notification-service/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   },
   moduleNameMapper: {
     '^@send/shared$': '<rootDir>/../../shared/src',
+    '^@send/shared/(.*)$': '<rootDir>/../../shared/src/$1',
   },
   coverageDirectory: 'coverage',
   collectCoverageFrom: [

--- a/packages/vehicle-service/jest.config.js
+++ b/packages/vehicle-service/jest.config.js
@@ -7,4 +7,8 @@ module.exports = {
   },
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-}; 
+  moduleNameMapper: {
+    '^@send/shared$': '<rootDir>/../../shared/src',
+    '^@send/shared/(.*)$': '<rootDir>/../../shared/src/$1',
+  },
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,8 @@
     "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {
+      "@send/shared": ["packages/shared/src"],
+      "@send/shared/*": ["packages/shared/src/*"],
       "@send/*": ["packages/*/src"],
       "@shared/*": ["packages/shared/src/*"]
     },


### PR DESCRIPTION
## Summary
- update path aliases for shared package
- map `@send/shared/*` in Jest configs

## Testing
- `npx tsc -p packages/driver-service/tsconfig.json` *(fails: Cannot find type definition file for 'express')*
- `npx tsc -p packages/run-service/tsconfig.json` *(fails: Output file ... has not been built from source file)*
- `npx tsc -p packages/system-notification-service/tsconfig.json` *(fails: Output file ... has not been built from source file)*
- `npx tsc -p packages/vehicle-service/tsconfig.json` *(fails: Cannot find type definition file for 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684184b9d6508333aadea99b4a33f09a