### PR TITLE
Implement API Gateway

### DIFF
--- a/packages/api-gateway/README.md
+++ b/packages/api-gateway/README.md
@@ -1,7 +1,34 @@
 # API Gateway
 
-This directory currently contains documentation for the planned API Gateway service.
+The API Gateway exposes a single entry point for all client requests. It proxies
+traffic to the underlying services and enforces authentication using the shared
+`authenticate` middleware.
 
-The gateway will route external requests to internal services, provide authentication, and serve as a central point for monitoring.
+## Environment Variables
 
-Implementation is not yet available. Further details will be added as development progresses.
+- `PORT` - Port to run the gateway (default: `8080`)
+- `USER_SERVICE_URL` - URL of the user service (default: `http://localhost:3000`)
+- `RUN_SERVICE_URL` - URL of the run service (default: `http://localhost:3002`)
+- `STUDENT_SERVICE_URL` - URL of the student service (default: `http://localhost:3003`)
+- `DRIVER_SERVICE_URL` - URL of the driver service (default: `http://localhost:3004`)
+- `VEHICLE_SERVICE_URL` - URL of the vehicle service (default: `http://localhost:3005`)
+- `DOCUMENT_SERVICE_URL` - URL of the document service (default: `http://localhost:3006`)
+
+## Development
+
+```bash
+pnpm install
+pnpm --filter api-gateway dev
+```
+
+## Build
+
+```bash
+pnpm --filter api-gateway build
+```
+
+## Start
+
+```bash
+pnpm --filter api-gateway start
+```

--- a/packages/api-gateway/package.json
+++ b/packages/api-gateway/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "api-gateway",
+  "version": "1.0.0",
+  "description": "API Gateway for routing requests and unified authentication",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "start": "node dist/index.js",
+    "dev": "nodemon src/index.ts",
+    "build": "tsc",
+    "test": "jest --passWithNoTests",
+    "lint": "eslint src/**/*.ts",
+    "format": "prettier --write \"src/**/*.ts\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "http-proxy-middleware": "^2.0.6",
+    "shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.24",
+    "@typescript-eslint/eslint-plugin": "^7.0.1",
+    "@typescript-eslint/parser": "^7.0.1",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "jest": "^29.7.0",
+    "nodemon": "^3.0.3",
+    "prettier": "^3.2.5",
+    "typescript": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -1,0 +1,25 @@
+import express from 'express';
+import { createProxyMiddleware } from 'http-proxy-middleware';
+import { authenticate } from '@send/shared';
+import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
+import { serviceConfig } from './config';
+
+const app = express();
+
+app.use(express.json());
+app.use(securityHeaders);
+app.use(rateLimit('api-gateway'));
+
+// Apply authentication to all API routes
+app.use('/api', authenticate());
+
+// Proxy rules
+app.use('/api/auth', createProxyMiddleware({ target: serviceConfig.userService, changeOrigin: true }));
+app.use('/api/users', createProxyMiddleware({ target: serviceConfig.userService, changeOrigin: true }));
+app.use('/api/runs', createProxyMiddleware({ target: serviceConfig.runService, changeOrigin: true }));
+app.use('/api/students', createProxyMiddleware({ target: serviceConfig.studentService, changeOrigin: true }));
+app.use('/api/drivers', createProxyMiddleware({ target: serviceConfig.driverService, changeOrigin: true }));
+app.use('/api/vehicles', createProxyMiddleware({ target: serviceConfig.vehicleService, changeOrigin: true }));
+app.use('/api/documents', createProxyMiddleware({ target: serviceConfig.documentService, changeOrigin: true }));
+
+export default app;

--- a/packages/api-gateway/src/config.ts
+++ b/packages/api-gateway/src/config.ts
@@ -1,0 +1,8 @@
+export const serviceConfig = {
+  userService: process.env.USER_SERVICE_URL || 'http://localhost:3000',
+  runService: process.env.RUN_SERVICE_URL || 'http://localhost:3002',
+  studentService: process.env.STUDENT_SERVICE_URL || 'http://localhost:3003',
+  driverService: process.env.DRIVER_SERVICE_URL || 'http://localhost:3004',
+  vehicleService: process.env.VEHICLE_SERVICE_URL || 'http://localhost:3005',
+  documentService: process.env.DOCUMENT_SERVICE_URL || 'http://localhost:3006'
+};

--- a/packages/api-gateway/src/index.ts
+++ b/packages/api-gateway/src/index.ts
@@ -1,0 +1,7 @@
+import app from './app';
+
+const port = process.env.PORT || 8080;
+
+app.listen(port, () => {
+  console.log(`API Gateway running on port ${port}`);
+});

--- a/packages/api-gateway/tsconfig.json
+++ b/packages/api-gateway/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["../shared/src/*"],
+      "@send/shared": ["../shared/src"],
+      "@send/shared/*": ["../shared/src/*"]
+    },
+    "types": ["node", "jest", "express"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "references": [
+    { "path": "../shared" }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,55 @@ importers:
         specifier: ^6.6.2
         version: 6.6.2(encoding@0.1.13)
 
+  packages/api-gateway:
+    dependencies:
+      express:
+        specifier: ^4.18.2
+        version: 4.21.2
+      http-proxy-middleware:
+        specifier: ^2.0.6
+        version: 2.0.9(@types/express@4.17.21)
+      shared:
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.21
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.11.24
+        version: 20.17.30
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.0.1
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.0.1
+        version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@8.57.1)
+      eslint-plugin-prettier:
+        specifier: ^5.1.3
+        version: 5.2.6(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.5.3)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.17.30)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3))
+      nodemon:
+        specifier: ^3.0.3
+        version: 3.1.9
+      prettier:
+        specifier: ^3.2.5
+        version: 3.5.3
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+
   packages/document-service:
     dependencies:
       '@prisma/client':
@@ -2384,6 +2433,9 @@ packages:
   '@types/http-errors@2.0.4':
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
 
+  '@types/http-proxy@1.17.16':
+    resolution: {integrity: sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==}
+
   '@types/ioredis@4.28.10':
     resolution: {integrity: sha512-69LyhUgrXdgcNDv7ogs1qXZomnfOEnSmrmMFqKgt1XMJxmoOSG/u3wYy13yACIfKuMJ8IhKgHafDO3sx19zVQQ==}
 
@@ -4153,6 +4205,19 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  http-proxy-middleware@2.0.9:
+    resolution: {integrity: sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/express': ^4.17.13
+    peerDependenciesMeta:
+      '@types/express':
+        optional: true
+
+  http-proxy@1.18.1:
+    resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
+    engines: {node: '>=8.0.0'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -4337,6 +4402,10 @@ packages:
   is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
+
+  is-plain-obj@3.0.0:
+    resolution: {integrity: sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==}
+    engines: {node: '>=10'}
 
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
@@ -9069,6 +9138,10 @@ snapshots:
 
   '@types/http-errors@2.0.4': {}
 
+  '@types/http-proxy@1.17.16':
+    dependencies:
+      '@types/node': 20.17.30
+
   '@types/ioredis@4.28.10':
     dependencies:
       '@types/node': 20.17.30
@@ -10796,7 +10869,7 @@ snapshots:
       '@paralleldrive/cuid2': 2.2.2
       dezalgo: 1.0.4
       once: 1.4.0
-      qs: 6.13.0
+      qs: 6.14.0
 
   forwarded@0.2.0: {}
 
@@ -11145,6 +11218,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-proxy-middleware@2.0.9(@types/express@4.17.21):
+    dependencies:
+      '@types/http-proxy': 1.17.16
+      http-proxy: 1.18.1
+      is-glob: 4.0.3
+      is-plain-obj: 3.0.0
+      micromatch: 4.0.8
+    optionalDependencies:
+      '@types/express': 4.17.21
+    transitivePeerDependencies:
+      - debug
+
+  http-proxy@1.18.1:
+    dependencies:
+      eventemitter3: 4.0.7
+      follow-redirects: 1.15.9
+      requires-port: 1.0.0
+    transitivePeerDependencies:
+      - debug
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -11347,6 +11440,8 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-plain-obj@1.1.0: {}
+
+  is-plain-obj@3.0.0: {}
 
   is-plain-object@2.0.4:
     dependencies:
@@ -13622,7 +13717,7 @@ snapshots:
       formidable: 2.1.5
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.13.0
+      qs: 6.14.0
       semver: 7.7.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary
- add new API Gateway service with proxy routes and auth enforcement
- wire up basic configuration for service URLs
- document the API Gateway and how to run it

## Testing
- `pnpm test` *(fails: tasks for several services)*
- `pnpm --filter api-gateway build`
- `pnpm --filter api-gateway test`


------
https://chatgpt.com/codex/tasks/task_e_68419430e1bc8333acfd27997c11f429