### PR TITLE
Fix jest config for tracking service

### DIFF
--- a/packages/tracking-service/jest.config.js
+++ b/packages/tracking-service/jest.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  moduleNameMapper: {
+    '^@send/shared$': '<rootDir>/../shared/src',
+    '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
+    '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
+  },
+  coverageDirectory: 'coverage',
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/index.ts',
+    '!src/**/__tests__/**',
+  ],
+};


### PR DESCRIPTION
## Summary
- add a local Jest configuration for `tracking-service` so TypeScript tests are compiled with ts-jest

## Testing
- `pnpm test` *(fails: Lerna running target test for 10 projects)*

------
https://chatgpt.com/codex/tasks/task_e_684199cc29c8833395335d2de9104cc5