### PR TITLE
Fix pnpm ignored dependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,9 +9,6 @@ public-hoist-pattern:
 ignoredBuiltDependencies:
   - '@nestjs/core'
   - '@parcel/watcher'
-  - '@prisma/client'
-  - '@prisma/engines'
-  - 'prisma'
   - 'esbuild'
 
 node-linker: hoisted


### PR DESCRIPTION
## Summary
- stop ignoring `@prisma/client` and other prisma packages during build
- regenerate prisma clients

## Testing
- `pnpm install`
- `pnpm -r install`
- `npx prisma generate --schema=packages/driver-service/prisma/schema.prisma`
- `pnpm run generate:prisma`
- `pnpm run build` *(fails: DatabaseService properties missing)*


------
https://chatgpt.com/codex/tasks/task_e_68419bb7cb6883339161c261fe685d88