### PR TITLE
Fix amqplib stub typings

### DIFF
--- a/test/amqplib.ts
+++ b/test/amqplib.ts
@@ -1,23 +1,29 @@
 export interface Connection {
-  createChannel: () => any;
-  close: () => Promise<void>;
+  createChannel(): Promise<Channel>;
+  close(): Promise<void>;
 }
+
 export interface Channel {
-  assertExchange: () => any;
-  assertQueue: () => any;
-  bindQueue: () => any;
-  publish: () => any;
-  consume: () => any;
-  close: () => any;
+  assertExchange(exchange: string, type: string, options?: any): Promise<any>;
+  assertQueue(queue: string, options?: any): Promise<any>;
+  bindQueue(queue: string, source: string, pattern: string, args?: any): Promise<any>;
+  publish(exchange: string, routingKey: string, content: Buffer, options?: any): boolean;
+  consume(queue: string, onMessage: (msg: any | null) => void, options?: any): Promise<any>;
+  ack(message: any, allUpTo?: boolean): void;
+  nack(message: any, allUpTo?: boolean, requeue?: boolean): void;
+  close(): Promise<void>;
 }
-export const connect = async () => ({
+
+export const connect = async (_url: string): Promise<Connection> => ({
   createChannel: async () => ({
-    assertExchange: () => {},
-    assertQueue: () => {},
-    bindQueue: () => {},
-    publish: () => {},
-    consume: () => {},
-    close: () => {}
+    assertExchange: async () => ({}),
+    assertQueue: async () => ({}),
+    bindQueue: async () => ({}),
+    publish: () => true,
+    consume: async () => ({}),
+    ack: () => {},
+    nack: () => {},
+    close: async () => {}
   }),
   close: async () => {}
 });


### PR DESCRIPTION
## Summary
- update the amqplib stub with signatures compatible with the promise API
- confirm tsconfig for system-notification-service still maps to this stub

## Testing
- `npx lerna run test --scope system-notification-service` *(fails: Test suite failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_6841a0722898833389b9895eac76d5d5