### PR TITLE
Fix Geofence boundary type

### DIFF
--- a/packages/shared/src/types/tracking.ts
+++ b/packages/shared/src/types/tracking.ts
@@ -8,7 +8,7 @@ export interface Location {
 }
 
 export interface Geofence {
-  boundary(arg0: { latitude: number; longitude: number; }, boundary: any): unknown;
+  boundary: { latitude: number; longitude: number }[];
   id: string;
   name: string;
   type: 'PICKUP' | 'DROPOFF';


### PR DESCRIPTION
## Summary
- update `Geofence` type to have a `boundary` array of coordinates

## Testing
- `npm test` *(fails: Running target test for 10 projects failed)*

------
https://chatgpt.com/codex/tasks/task_e_6841a0784c0083339a86d09020eb9c1e