### PR TITLE
Update TrackingService test mocks

### DIFF
--- a/packages/tracking-service/src/infra/services/tracking.service.test.ts
+++ b/packages/tracking-service/src/infra/services/tracking.service.test.ts
@@ -1,12 +1,11 @@
 import { TrackingService } from './tracking.service';
-import { PrismaClient } from '@prisma/client';
 import { RabbitMQService } from '@shared/messaging/rabbitmq.service';
 import { Logger } from 'winston';
-import { Location, TrackingEvent, Geofence } from '@shared/types/tracking';
+import { Location } from '@shared/types/tracking';
 
 describe('TrackingService', () => {
   let trackingService: TrackingService;
-  let mockPrisma: jest.Mocked<PrismaClient>;
+  let mockPrisma: any;
   let mockRabbitMQ: jest.Mocked<RabbitMQService>;
   let mockLogger: jest.Mocked<Logger>;
 
@@ -44,7 +43,8 @@ describe('TrackingService', () => {
         latitude: 40.7128,
         longitude: -74.0060,
         speed: 60,
-        heading: 90
+        heading: 90,
+        timestamp: new Date()
       };
 
       const mockEvent = {
@@ -101,10 +101,11 @@ describe('TrackingService', () => {
         latitude: 40.7128,
         longitude: -74.0060,
         speed: 60,
-        heading: 90
+        heading: 90,
+        timestamp: new Date()
       };
 
-      const mockGeofence: Geofence = {
+      const mockGeofence = {
         id: 'geofence-1',
         name: 'Test Geofence',
         boundary: [
@@ -146,7 +147,8 @@ describe('TrackingService', () => {
         latitude: 40.7128,
         longitude: -74.0060,
         speed: 60,
-        heading: 90
+        heading: 90,
+        timestamp: new Date()
       };
 
       const error = new Error('Database error');


### PR DESCRIPTION
## Summary
- align tests with new TrackingService signature
- add timestamps to mocked Location objects

## Testing
- `npx jest --runTestsByPath src/infra/services/tracking.service.test.ts src/__tests__/services/tracking.service.test.ts` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*

------
https://chatgpt.com/codex/tasks/task_e_6841a07f049c8333921fd4bf4ce9e3d9