### PR TITLE
Fix jest mapper for vehicle-service

### DIFF
--- a/packages/vehicle-service/jest.config.js
+++ b/packages/vehicle-service/jest.config.js
@@ -10,5 +10,6 @@ module.exports = {
   moduleNameMapper: {
     '^@send/shared$': '<rootDir>/../../shared/src',
     '^@send/shared/(.*)$': '<rootDir>/../../shared/src/$1',
+    '^@shared/(.*)$': '<rootDir>/../../shared/src/$1',
   },
 };


### PR DESCRIPTION
## Summary
- update `vehicle-service` jest config to map `@shared/*`

## Testing
- `npm test --workspace packages/vehicle-service` *(fails: Module '@prisma/client' has no exported member)*

------
https://chatgpt.com/codex/tasks/task_e_6841a084f074833388a7965ddd18f0e1