### PR TITLE
Fix VehicleService instantiation and tests

### DIFF
--- a/packages/vehicle-service/src/__tests__/controllers/vehicle.controller.test.ts
+++ b/packages/vehicle-service/src/__tests__/controllers/vehicle.controller.test.ts
@@ -20,7 +20,6 @@ describe('VehicleController', () => {
       deleteVehicle: jest.fn(),
       getAllVehicles: jest.fn(),
       addMaintenanceRecord: jest.fn(),
-      updateVehicleStatus: jest.fn(),
       assignVehicleToRun: jest.fn(),
       unassignVehicleFromRun: jest.fn()
     } as any;
@@ -288,7 +287,7 @@ describe('VehicleController', () => {
         status: VehicleStatus.MAINTENANCE
       };
 
-      vehicleService.updateVehicleStatus.mockResolvedValue(mockVehicle);
+      vehicleService.updateVehicle.mockResolvedValue(mockVehicle);
 
       const response = await request(app)
         .put('/vehicles/1/status')
@@ -296,11 +295,11 @@ describe('VehicleController', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(mockVehicle);
-      expect(vehicleService.updateVehicleStatus).toHaveBeenCalledWith('1', status);
+      expect(vehicleService.updateVehicle).toHaveBeenCalledWith('1', { status });
     });
 
     it('should return 404 if vehicle not found', async () => {
-      vehicleService.updateVehicleStatus.mockResolvedValue(null);
+      vehicleService.updateVehicle.mockResolvedValue(null);
 
       const response = await request(app)
         .put('/vehicles/1/status')
@@ -311,7 +310,7 @@ describe('VehicleController', () => {
     });
 
     it('should handle errors', async () => {
-      vehicleService.updateVehicleStatus.mockRejectedValue(new Error('Test error'));
+      vehicleService.updateVehicle.mockRejectedValue(new Error('Test error'));
 
       const response = await request(app)
         .put('/vehicles/1/status')

--- a/packages/vehicle-service/src/__tests__/vehicle.performance.test.ts
+++ b/packages/vehicle-service/src/__tests__/vehicle.performance.test.ts
@@ -13,7 +13,7 @@ describe('Vehicle Service Performance', () => {
   beforeAll(async () => {
     testSetup = await setupTestEnvironment();
     prisma = testSetup.getPrisma();
-    vehicleService = new VehicleService(prisma);
+    vehicleService = new VehicleService();
 
     // Create test vehicles
     const vehicles = Array.from({ length: NUM_VEHICLES }, (_, i) => ({


### PR DESCRIPTION
## Summary
- use `VehicleService` constructor without arguments in performance test
- replace `updateVehicleStatus` mock calls with `updateVehicle`

## Testing
- `npm test` *(fails: Lerna running target test for 10 projects failed)*

------
https://chatgpt.com/codex/tasks/task_e_6841a08aad548333896664fefaedb9df