### PR TITLE
Annotate tx type and extend Prisma stub

### DIFF
--- a/packages/document-service/src/services/document.service.ts
+++ b/packages/document-service/src/services/document.service.ts
@@ -76,7 +76,7 @@ export class DocumentService {
         .promise();
 
       // Create document record
-      const document = await this.prisma.$transaction(async (tx) => {
+      const document = await this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
         const doc = await (tx as any).document.create({
           data: {
             userId,

--- a/test/prisma-client.ts
+++ b/test/prisma-client.ts
@@ -1,4 +1,10 @@
 export class PrismaClient {
   [key: string]: any;
 }
+
 export const Prisma = {} as any;
+
+export namespace Prisma {
+  export type JsonObject = any;
+  export type TransactionClient = PrismaClient;
+}


### PR DESCRIPTION
## Summary
- annotate the Prisma `$transaction` callback parameter with `Prisma.TransactionClient`
- expand the test Prisma client stub with `JsonObject` and `TransactionClient`

## Testing
- `npx tsc -p packages/document-service/tsconfig.test.json --noEmit` *(fails: `npx: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841a09212ac83339d232b236da6b5f0