### PR TITLE
Fix vehicle-service shared import paths

### DIFF
--- a/packages/vehicle-service/src/__tests__/vehicle.test.ts
+++ b/packages/vehicle-service/src/__tests__/vehicle.test.ts
@@ -1,7 +1,7 @@
-import { setupTestEnvironment, cleanupTestEnvironment } from '@send/shared/src/testing/setup';
+import { setupTestEnvironment, cleanupTestEnvironment } from '@send/shared/testing/setup';
 import { VehicleService } from '../services/vehicle.service';
 import { PrismaClient } from '@prisma/client';
-import { VehicleStatus, VehicleType } from '@send/shared/src/types/vehicle';
+import { VehicleStatus, VehicleType } from '@send/shared/types/vehicle';
 
 describe('Vehicle Service', () => {
   let testSetup: any;

--- a/packages/vehicle-service/tsconfig.json
+++ b/packages/vehicle-service/tsconfig.json
@@ -5,6 +5,8 @@
     "rootDir": "../..",
     "baseUrl": ".",
     "paths": {
+      "@send/shared": ["../shared/src"],
+      "@send/shared/*": ["../shared/src/*"],
       "@services/*": ["./src/services/*"],
       "@types/*": ["./src/types/*"],
       "@shared/*": ["../shared/src/*"]


### PR DESCRIPTION
## Summary
- update test imports to use `@send/shared/testing/setup` and `@send/shared/types/vehicle`
- expose shared aliases in `tsconfig.json` so tests can compile

## Testing
- `npm test` (fails: Module '@prisma/client' has no exported member 'PrismaClient')

------
https://chatgpt.com/codex/tasks/task_e_6841b40019848333ab4a2d600782a069