### PR TITLE
Fix Prisma stub types

### DIFF
--- a/test/prisma-client.ts
+++ b/test/prisma-client.ts
@@ -2,7 +2,7 @@ export class PrismaClient {
   [key: string]: any
 }
 
-export const Prisma = {} as any;
+export var Prisma: any = {};
 
 export namespace Prisma {
   // Original exports
@@ -16,3 +16,4 @@ export namespace Prisma {
   // Newly added exports
   export type JsonObject = any
   export type TransactionClient = PrismaClient
+}


### PR DESCRIPTION
## Summary
- ensure the Prisma namespace in the test stub exports `JsonObject` and `TransactionClient`
- close the namespace properly and keep a value export to satisfy imports

## Testing
- `pnpm --filter document-service test` *(fails: Cannot find namespace 'Prisma')*

------
https://chatgpt.com/codex/tasks/task_e_6841b404bbd08333a7937cf7fb74fc80