### PR TITLE
Refactor shared types export

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,9 +1,6 @@
 export * from './types';
-export * from './types/run';
-export * from './types/student';
-export * from './types/driver';
 export * from './prometheus';
 export * from './logger';
 export * from './testing/setup';
 export { PrismaClient } from '@prisma/client';
-export { authenticate, requireRole } from './security/auth'; 
+export { authenticate, requireRole } from './security/auth';

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,58 +1,16 @@
-export enum VehicleStatus {
-  ACTIVE = 'ACTIVE',
-  MAINTENANCE = 'MAINTENANCE',
-  OUT_OF_SERVICE = 'OUT_OF_SERVICE'
-}
-
-export enum UserRole {
-  ADMIN = 'ADMIN',
-  DRIVER = 'DRIVER',
-  PA = 'PA',
-  GUARDIAN = 'GUARDIAN'
-}
-
-export enum UserStatus {
-  ACTIVE = 'ACTIVE',
-  INACTIVE = 'INACTIVE',
-  SUSPENDED = 'SUSPENDED'
-}
-
-export interface UserPayload {
-  id: string;
-  email: string;
-  role: UserRole;
-  roles: UserRole[];
-}
-
-export interface AuthenticatedRequest extends Express.Request {
-  user?: UserPayload;
-}
-
-export interface DriverData {
-  licenseNumber: string;
-  licenseExpiry: Date;
-}
-
-export interface PAData {
-  certification?: string;
-}
-
-export interface GuardianData {
-  address: string;
-  children?: string[];
-}
-
-export interface User {
-  id: string;
-  email: string;
-  firstName: string;
-  lastName: string;
-  role: UserRole;
-  roles: UserRole[];
-  status: UserStatus;
-  driverData?: DriverData;
-  paData?: PAData;
-  guardianData?: GuardianData;
-  createdAt: Date;
-  updatedAt: Date;
-} 
+export * from './vehicle';
+export * from './run';
+export * from './user';
+export { DriverStatus, Driver as DriverRecord } from './driver';
+export * from './student';
+export * from './document';
+export * from './service';
+export {
+  Location as TrackingLocation,
+  Geofence,
+  GeofenceEvent,
+  ETACalculation,
+  Journey,
+  TrackingEvent,
+  TrackingNotification
+} from './tracking';


### PR DESCRIPTION
## Summary
- simplify shared types entrypoint and avoid duplicate exports
- streamline shared package barrel file

## Testing
- `npm test` *(fails: Cannot find module '@shared/logger' and other runtime errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841c471e6f88333b2cfdc4ea9383803