### PR TITLE
Add shared module resolver for tests

### DIFF
--- a/packages/system-notification-service/jest.config.js
+++ b/packages/system-notification-service/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
   moduleNameMapper: {
     '^@send/shared$': '<rootDir>/../../shared/src',
     '^@send/shared/(.*)$': '<rootDir>/../../shared/src/$1',
+    '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
     '^@prisma/client$': '<rootDir>/../../test/prisma-client.ts'
   },
   globals: {


### PR DESCRIPTION
## Summary
- map `@shared/*` in system-notification-service Jest config so that tests can resolve shared modules

## Testing
- `npm --workspace=packages/system-notification-service test` *(fails: expect...toHaveBeenCalledWith)*

------
https://chatgpt.com/codex/tasks/task_e_6841c478a2f48333b742268d54853157