### PR TITLE
Add warn mock to document service tests

### DIFF
--- a/packages/document-service/src/__tests__/services/document.service.test.ts
+++ b/packages/document-service/src/__tests__/services/document.service.test.ts
@@ -65,7 +65,8 @@ jest.mock('winston', () => ({
   Logger: jest.fn().mockImplementation(() => ({
     info: jest.fn(),
     error: jest.fn(),
-    debug: jest.fn()
+    debug: jest.fn(),
+    warn: jest.fn()
   }))
 }));
 


### PR DESCRIPTION
## Summary
- extend `winston` Logger mock in document service tests to include `warn`

## Testing
- `npm test --workspace=packages/document-service`


------
https://chatgpt.com/codex/tasks/task_e_6841c47e06e483339137b2c0bfff7770