### PR TITLE
Add Prisma enum stubs

### DIFF
--- a/test/prisma-client.ts
+++ b/test/prisma-client.ts
@@ -2,6 +2,41 @@ export class PrismaClient {
   [key: string]: any
 }
 
+// Enum stubs used in tests
+export enum VehicleStatus {
+  AVAILABLE = 'AVAILABLE',
+  IN_USE = 'IN_USE',
+  MAINTENANCE = 'MAINTENANCE',
+  OUT_OF_SERVICE = 'OUT_OF_SERVICE'
+}
+
+export enum VehicleType {
+  SEDAN = 'SEDAN',
+  SUV = 'SUV',
+  VAN = 'VAN',
+  BUS = 'BUS'
+}
+
+export enum RunStatus {
+  PENDING = 'PENDING',
+  IN_PROGRESS = 'IN_PROGRESS',
+  COMPLETED = 'COMPLETED',
+  CANCELLED = 'CANCELLED'
+}
+
+export enum RunType {
+  REGULAR = 'REGULAR',
+  SPECIAL = 'SPECIAL',
+  EMERGENCY = 'EMERGENCY'
+}
+
+export enum ScheduleType {
+  ONE_TIME = 'ONE_TIME',
+  DAILY = 'DAILY',
+  WEEKLY = 'WEEKLY',
+  CUSTOM = 'CUSTOM'
+}
+
 
 export function Prisma() {}
 
@@ -10,7 +45,12 @@ export function Prisma() {}
 export namespace Prisma {
   // Original exports
   export type RunGetPayload<T> = any
-  export interface RunWhereInput {}
+  export interface RunWhereInput {
+    status?: any
+    type?: any
+    driverId?: string
+    paId?: string
+  }
   export const sql: any = undefined
   export const join: any = undefined
   export const empty: any = undefined


### PR DESCRIPTION
## Summary
- define enum types in test prisma stub
- extend RunWhereInput type with optional fields

## Testing
- `npm test` *(fails: Running target test for 10 projects failed)*

------
https://chatgpt.com/codex/tasks/task_e_6841c4855e7483338ab16d034acca943