### PR TITLE
Fix run model mapping type

### DIFF
--- a/packages/run-service/src/data/models/run.model.ts
+++ b/packages/run-service/src/data/models/run.model.ts
@@ -69,7 +69,7 @@ export class RunModel {
       }
     });
 
-    return runs.map(run => this.mapPrismaRunToRun(run));
+    return runs.map((run: PrismaRun) => this.mapPrismaRunToRun(run));
   }
 
   async delete(id: string): Promise<Run> {


### PR DESCRIPTION
## Summary
- explicitly type parameter in RunModel.findAll mapping

## Testing
- `npm test` *(fails: Module '@prisma/client' has no exported member 'Run', etc.)*
- `cd packages/run-service && npm test` *(fails: Property 'status' does not exist on type 'RunWhereInput', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6841c48eb9c48333b018bced13979bc3