### PR TITLE
Implement document service API

### DIFF
--- a/packages/document-service/src/__tests__/services/document.service.test.ts
+++ b/packages/document-service/src/__tests__/services/document.service.test.ts
@@ -12,7 +12,9 @@ jest.mock('@prisma/client', () => {
     document: {
       create: jest.fn(),
       findUnique: jest.fn(),
-      update: jest.fn()
+      update: jest.fn(),
+      findMany: jest.fn(),
+      delete: jest.fn()
     },
     documentVersion: {
       create: jest.fn(),
@@ -308,6 +310,33 @@ describe('DocumentService', () => {
           expiresAt: expect.any(Date)
         }
       });
+    });
+  });
+
+  describe('listDocuments', () => {
+    it('should return documents filtered by userId and type', async () => {
+      const docs = [
+        { id: '1', userId: 'u1', type: 'LICENSE' },
+        { id: '2', userId: 'u1', type: 'DBS' },
+      ];
+      mockPrisma.document.findMany.mockResolvedValue(docs);
+
+      const result = await documentService.listDocuments({ userId: 'u1', type: 'LICENSE' });
+
+      expect(mockPrisma.document.findMany).toHaveBeenCalledWith({
+        where: { userId: 'u1', type: 'LICENSE' },
+      });
+      expect(result[0].id).toBe('1');
+    });
+  });
+
+  describe('deleteDocument', () => {
+    it('should delete a document by id', async () => {
+      mockPrisma.document.delete.mockResolvedValue({});
+
+      await documentService.deleteDocument('doc1');
+
+      expect(mockPrisma.document.delete).toHaveBeenCalledWith({ where: { id: 'doc1' } });
     });
   });
 }); 

--- a/packages/document-service/src/api/controllers/document.controller.ts
+++ b/packages/document-service/src/api/controllers/document.controller.ts
@@ -1,0 +1,68 @@
+import { Request, Response } from 'express';
+import { DocumentService } from '../../services/document.service';
+import { Document } from '@shared/types/document';
+
+export class DocumentController {
+  constructor(private readonly documentService: DocumentService) {}
+
+  async uploadDocument(req: Request, res: Response): Promise<void> {
+    try {
+      const { userId, type, metadata } = req.body;
+      const file = req.file as Express.Multer.File;
+      if (!file) {
+        res.status(400).json({ error: 'File is required' });
+        return;
+      }
+      const document = await this.documentService.uploadDocument(userId, {
+        originalname: file.originalname,
+        mimetype: file.mimetype,
+        size: file.size,
+        buffer: file.buffer,
+      }, type, metadata || {});
+      res.status(201).json(document);
+    } catch (error) {
+      console.error('Failed to upload document:', error);
+      res.status(500).json({ error: 'Failed to upload document' });
+    }
+  }
+
+  async getDocumentById(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const doc = await this.documentService.getDocumentById(id);
+      if (!doc) {
+        res.status(404).json({ error: 'Document not found' });
+        return;
+      }
+      res.json(doc);
+    } catch (error) {
+      console.error('Failed to get document:', error);
+      res.status(500).json({ error: 'Failed to get document' });
+    }
+  }
+
+  async listDocuments(req: Request, res: Response): Promise<void> {
+    try {
+      const { userId, type } = req.query;
+      const docs = await this.documentService.listDocuments({
+        userId: userId as string | undefined,
+        type: type as string | undefined,
+      });
+      res.json(docs);
+    } catch (error) {
+      console.error('Failed to list documents:', error);
+      res.status(500).json({ error: 'Failed to list documents' });
+    }
+  }
+
+  async deleteDocument(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      await this.documentService.deleteDocument(id);
+      res.status(204).send();
+    } catch (error) {
+      console.error('Failed to delete document:', error);
+      res.status(500).json({ error: 'Failed to delete document' });
+    }
+  }
+}

--- a/packages/document-service/src/api/routes/document.routes.ts
+++ b/packages/document-service/src/api/routes/document.routes.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import multer from 'multer';
+import { DocumentController } from '../controllers/document.controller';
+
+export function createDocumentRoutes(controller: DocumentController): Router {
+  const router = Router();
+  const upload = multer();
+
+  router.post('/', upload.single('file'), controller.uploadDocument.bind(controller));
+  router.get('/', controller.listDocuments.bind(controller));
+  router.get('/:id', controller.getDocumentById.bind(controller));
+  router.delete('/:id', controller.deleteDocument.bind(controller));
+
+  return router;
+}

--- a/packages/document-service/src/index.ts
+++ b/packages/document-service/src/index.ts
@@ -1,0 +1,23 @@
+import { app, prisma, rabbitMQ, logger } from './app';
+
+const port = process.env.PORT || 3006;
+
+async function start() {
+  try {
+    await rabbitMQ.connect();
+    app.listen(port, () => {
+      console.log(`Document service running on port ${port}`);
+    });
+  } catch (err) {
+    logger.error('Failed to start document service', { error: err });
+    process.exit(1);
+  }
+}
+
+start();
+
+process.on('SIGTERM', async () => {
+  await rabbitMQ.close();
+  await prisma.$disconnect();
+  process.exit(0);
+});

--- a/packages/document-service/src/services/document.service.ts
+++ b/packages/document-service/src/services/document.service.ts
@@ -155,6 +155,19 @@ export class DocumentService {
     return versions.map(this.mapToSharedDocumentVersion);
   }
 
+  async listDocuments(filters: { userId?: string; type?: string } = {}): Promise<Document[]> {
+    const where: any = {};
+    if (filters.userId) where.userId = filters.userId;
+    if (filters.type) where.type = filters.type;
+
+    const documents = await (this.prisma as any).document.findMany({ where });
+    return documents.map((d: any) => this.mapToSharedDocument(d));
+  }
+
+  async deleteDocument(id: string): Promise<void> {
+    await (this.prisma as any).document.delete({ where: { id } });
+  }
+
   async updateDocumentAccess(
     documentId: string,
     userId: string,


### PR DESCRIPTION
## Summary
- add document controller and routes
- expose document service server entrypoint
- implement list and delete methods
- cover new logic with unit tests

## Testing
- `pnpm --filter document-service test`
- `pnpm run test` *(fails: driver-service, system-notification-service)*

------
https://chatgpt.com/codex/tasks/task_e_6841cb3004cc83339e52d691e2bcce2f