### PR TITLE
Add missing microservices

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This repository contains the microservices that make up the **SEN Dispatch** sys
 - **driver-service** – driver related APIs
 - **student-service** – student records and assignments
 - **document-service** – secure document storage
+- **incident-service** – incident reporting and management
+- **invoicing-service** – invoice generation APIs
+- **admin-service** – admin dashboard metrics and reports
 - **system-notification-service** – delivery of notifications (email, SMS, push)
 - **shared** – common utilities and TypeScript types
 
@@ -102,7 +105,7 @@ pnpm dev
 
 ### Other Services
 
-`student-service` and `document-service` follow the same basic pattern:
+`student-service`, `document-service`, `incident-service`, `invoicing-service`, and `admin-service` follow the same basic pattern:
 
 ```bash
 pnpm install

--- a/packages/admin-service/jest.config.js
+++ b/packages/admin-service/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  moduleNameMapper: {
+    '^@send/shared$': '<rootDir>/../shared/src',
+    '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
+    '^@shared/(.*)$': '<rootDir>/../shared/src/$1'
+  }
+};

--- a/packages/admin-service/package.json
+++ b/packages/admin-service/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "admin-service",
+  "version": "1.0.0",
+  "description": "Administrative metrics and reporting service",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "nodemon src/index.ts",
+    "test": "jest",
+    "lint": "eslint src/**/*.ts",
+    "format": "prettier --write \"src/**/*.ts\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.24",
+    "@typescript-eslint/eslint-plugin": "^7.0.1",
+    "@typescript-eslint/parser": "^7.0.1",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "jest": "^29.7.0",
+    "nodemon": "^3.0.3",
+    "prettier": "^3.2.5",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/admin-service/src/api/controllers/admin.controller.ts
+++ b/packages/admin-service/src/api/controllers/admin.controller.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+
+export class AdminController {
+  async metrics(req: Request, res: Response): Promise<void> {
+    res.json({
+      totalRunsToday: 0,
+      onTimePercentage: 0,
+      openIncidents: 0,
+      expiringDocuments: 0
+    });
+  }
+
+  async reports(req: Request, res: Response): Promise<void> {
+    res.json([]);
+  }
+}

--- a/packages/admin-service/src/api/routes/admin.routes.ts
+++ b/packages/admin-service/src/api/routes/admin.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { AdminController } from '../controllers/admin.controller';
+
+export function createAdminRoutes(controller: AdminController): Router {
+  const router = Router();
+
+  router.get('/admin/metrics', controller.metrics.bind(controller));
+  router.get('/admin/reports', controller.reports.bind(controller));
+
+  return router;
+}

--- a/packages/admin-service/src/app.ts
+++ b/packages/admin-service/src/app.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import compression from 'compression';
+import { AdminController } from './api/controllers/admin.controller';
+import { createAdminRoutes } from './api/routes/admin.routes';
+
+const controller = new AdminController();
+
+const app = express();
+app.use(express.json());
+app.use(cors());
+app.use(helmet());
+app.use(compression());
+
+app.use('/api', createAdminRoutes(controller));
+
+export default app;

--- a/packages/admin-service/src/index.ts
+++ b/packages/admin-service/src/index.ts
@@ -1,0 +1,7 @@
+import app from './app';
+
+const port = process.env.PORT || 3012;
+
+app.listen(port, () => {
+  console.log(`Admin service running on port ${port}`);
+});

--- a/packages/admin-service/tsconfig.json
+++ b/packages/admin-service/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": "./src",
+    "paths": {
+      "@shared/*": ["../../shared/src/*"],
+      "@send/shared": ["../../shared/src"],
+      "@send/shared/*": ["../../shared/src/*"]
+    },
+    "types": ["node", "jest", "express"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -21,5 +21,8 @@ app.use('/api/students', createProxyMiddleware({ target: serviceConfig.studentSe
 app.use('/api/drivers', createProxyMiddleware({ target: serviceConfig.driverService, changeOrigin: true }));
 app.use('/api/vehicles', createProxyMiddleware({ target: serviceConfig.vehicleService, changeOrigin: true }));
 app.use('/api/documents', createProxyMiddleware({ target: serviceConfig.documentService, changeOrigin: true }));
+app.use('/api/incidents', createProxyMiddleware({ target: serviceConfig.incidentService, changeOrigin: true }));
+app.use('/api/invoices', createProxyMiddleware({ target: serviceConfig.invoicingService, changeOrigin: true }));
+app.use('/api/admin', createProxyMiddleware({ target: serviceConfig.adminService, changeOrigin: true }));
 
 export default app;

--- a/packages/api-gateway/src/config.ts
+++ b/packages/api-gateway/src/config.ts
@@ -4,5 +4,8 @@ export const serviceConfig = {
   studentService: process.env.STUDENT_SERVICE_URL || 'http://localhost:3003',
   driverService: process.env.DRIVER_SERVICE_URL || 'http://localhost:3004',
   vehicleService: process.env.VEHICLE_SERVICE_URL || 'http://localhost:3005',
-  documentService: process.env.DOCUMENT_SERVICE_URL || 'http://localhost:3006'
+  documentService: process.env.DOCUMENT_SERVICE_URL || 'http://localhost:3006',
+  incidentService: process.env.INCIDENT_SERVICE_URL || 'http://localhost:3010',
+  invoicingService: process.env.INVOICING_SERVICE_URL || 'http://localhost:3011',
+  adminService: process.env.ADMIN_SERVICE_URL || 'http://localhost:3012'
 };

--- a/packages/document-service/src/__tests__/services/document.service.test.ts
+++ b/packages/document-service/src/__tests__/services/document.service.test.ts
@@ -12,7 +12,9 @@ jest.mock('@prisma/client', () => {
     document: {
       create: jest.fn(),
       findUnique: jest.fn(),
-      update: jest.fn()
+      update: jest.fn(),
+      findMany: jest.fn(),
+      delete: jest.fn()
     },
     documentVersion: {
       create: jest.fn(),
@@ -308,6 +310,33 @@ describe('DocumentService', () => {
           expiresAt: expect.any(Date)
         }
       });
+    });
+  });
+
+  describe('listDocuments', () => {
+    it('should return documents filtered by userId and type', async () => {
+      const docs = [
+        { id: '1', userId: 'u1', type: 'LICENSE' },
+        { id: '2', userId: 'u1', type: 'DBS' },
+      ];
+      mockPrisma.document.findMany.mockResolvedValue(docs);
+
+      const result = await documentService.listDocuments({ userId: 'u1', type: 'LICENSE' });
+
+      expect(mockPrisma.document.findMany).toHaveBeenCalledWith({
+        where: { userId: 'u1', type: 'LICENSE' },
+      });
+      expect(result[0].id).toBe('1');
+    });
+  });
+
+  describe('deleteDocument', () => {
+    it('should delete a document by id', async () => {
+      mockPrisma.document.delete.mockResolvedValue({});
+
+      await documentService.deleteDocument('doc1');
+
+      expect(mockPrisma.document.delete).toHaveBeenCalledWith({ where: { id: 'doc1' } });
     });
   });
 }); 

--- a/packages/document-service/src/api/controllers/document.controller.ts
+++ b/packages/document-service/src/api/controllers/document.controller.ts
@@ -1,0 +1,68 @@
+import { Request, Response } from 'express';
+import { DocumentService } from '../../services/document.service';
+import { Document } from '@shared/types/document';
+
+export class DocumentController {
+  constructor(private readonly documentService: DocumentService) {}
+
+  async uploadDocument(req: Request, res: Response): Promise<void> {
+    try {
+      const { userId, type, metadata } = req.body;
+      const file = req.file as Express.Multer.File;
+      if (!file) {
+        res.status(400).json({ error: 'File is required' });
+        return;
+      }
+      const document = await this.documentService.uploadDocument(userId, {
+        originalname: file.originalname,
+        mimetype: file.mimetype,
+        size: file.size,
+        buffer: file.buffer,
+      }, type, metadata || {});
+      res.status(201).json(document);
+    } catch (error) {
+      console.error('Failed to upload document:', error);
+      res.status(500).json({ error: 'Failed to upload document' });
+    }
+  }
+
+  async getDocumentById(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const doc = await this.documentService.getDocumentById(id);
+      if (!doc) {
+        res.status(404).json({ error: 'Document not found' });
+        return;
+      }
+      res.json(doc);
+    } catch (error) {
+      console.error('Failed to get document:', error);
+      res.status(500).json({ error: 'Failed to get document' });
+    }
+  }
+
+  async listDocuments(req: Request, res: Response): Promise<void> {
+    try {
+      const { userId, type } = req.query;
+      const docs = await this.documentService.listDocuments({
+        userId: userId as string | undefined,
+        type: type as string | undefined,
+      });
+      res.json(docs);
+    } catch (error) {
+      console.error('Failed to list documents:', error);
+      res.status(500).json({ error: 'Failed to list documents' });
+    }
+  }
+
+  async deleteDocument(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      await this.documentService.deleteDocument(id);
+      res.status(204).send();
+    } catch (error) {
+      console.error('Failed to delete document:', error);
+      res.status(500).json({ error: 'Failed to delete document' });
+    }
+  }
+}

--- a/packages/document-service/src/api/routes/document.routes.ts
+++ b/packages/document-service/src/api/routes/document.routes.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import multer from 'multer';
+import { DocumentController } from '../controllers/document.controller';
+
+export function createDocumentRoutes(controller: DocumentController): Router {
+  const router = Router();
+  const upload = multer();
+
+  router.post('/', upload.single('file'), controller.uploadDocument.bind(controller));
+  router.get('/', controller.listDocuments.bind(controller));
+  router.get('/:id', controller.getDocumentById.bind(controller));
+  router.delete('/:id', controller.deleteDocument.bind(controller));
+
+  return router;
+}

--- a/packages/document-service/src/index.ts
+++ b/packages/document-service/src/index.ts
@@ -1,0 +1,23 @@
+import { app, prisma, rabbitMQ, logger } from './app';
+
+const port = process.env.PORT || 3006;
+
+async function start() {
+  try {
+    await rabbitMQ.connect();
+    app.listen(port, () => {
+      console.log(`Document service running on port ${port}`);
+    });
+  } catch (err) {
+    logger.error('Failed to start document service', { error: err });
+    process.exit(1);
+  }
+}
+
+start();
+
+process.on('SIGTERM', async () => {
+  await rabbitMQ.close();
+  await prisma.$disconnect();
+  process.exit(0);
+});

--- a/packages/document-service/src/services/document.service.ts
+++ b/packages/document-service/src/services/document.service.ts
@@ -155,6 +155,19 @@ export class DocumentService {
     return versions.map(this.mapToSharedDocumentVersion);
   }
 
+  async listDocuments(filters: { userId?: string; type?: string } = {}): Promise<Document[]> {
+    const where: any = {};
+    if (filters.userId) where.userId = filters.userId;
+    if (filters.type) where.type = filters.type;
+
+    const documents = await (this.prisma as any).document.findMany({ where });
+    return documents.map((d: any) => this.mapToSharedDocument(d));
+  }
+
+  async deleteDocument(id: string): Promise<void> {
+    await (this.prisma as any).document.delete({ where: { id } });
+  }
+
   async updateDocumentAccess(
     documentId: string,
     userId: string,

--- a/packages/incident-service/jest.config.js
+++ b/packages/incident-service/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  moduleNameMapper: {
+    '^@send/shared$': '<rootDir>/../shared/src',
+    '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
+    '^@shared/(.*)$': '<rootDir>/../shared/src/$1'
+  }
+};

--- a/packages/incident-service/package.json
+++ b/packages/incident-service/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "incident-service",
+  "version": "1.0.0",
+  "description": "Incident reporting and management service",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "nodemon src/index.ts",
+    "test": "jest",
+    "lint": "eslint src/**/*.ts",
+    "format": "prettier --write \"src/**/*.ts\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.24",
+    "@typescript-eslint/eslint-plugin": "^7.0.1",
+    "@typescript-eslint/parser": "^7.0.1",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "jest": "^29.7.0",
+    "nodemon": "^3.0.3",
+    "prettier": "^3.2.5",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/incident-service/src/api/controllers/incident.controller.ts
+++ b/packages/incident-service/src/api/controllers/incident.controller.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from 'express';
+import { IncidentService } from '../../services/incident.service';
+
+export class IncidentController {
+  constructor(private readonly incidentService: IncidentService) {}
+
+  async create(req: Request, res: Response): Promise<void> {
+    try {
+      const incident = await this.incidentService.createIncident(req.body);
+      res.status(201).json(incident);
+    } catch (err) {
+      res.status(500).json({ error: 'Failed to create incident' });
+    }
+  }
+
+  async list(req: Request, res: Response): Promise<void> {
+    const incidents = await this.incidentService.listIncidents();
+    res.json(incidents);
+  }
+
+  async getById(req: Request, res: Response): Promise<void> {
+    const incident = await this.incidentService.getIncident(req.params.id);
+    if (!incident) {
+      res.status(404).json({ error: 'Incident not found' });
+      return;
+    }
+    res.json(incident);
+  }
+
+  async update(req: Request, res: Response): Promise<void> {
+    const incident = await this.incidentService.updateIncident(req.params.id, req.body);
+    if (!incident) {
+      res.status(404).json({ error: 'Incident not found' });
+      return;
+    }
+    res.json(incident);
+  }
+
+  async remove(req: Request, res: Response): Promise<void> {
+    const deleted = await this.incidentService.deleteIncident(req.params.id);
+    if (!deleted) {
+      res.status(404).json({ error: 'Incident not found' });
+      return;
+    }
+    res.status(204).send();
+  }
+}

--- a/packages/incident-service/src/api/routes/incident.routes.ts
+++ b/packages/incident-service/src/api/routes/incident.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { IncidentController } from '../controllers/incident.controller';
+
+export function createIncidentRoutes(controller: IncidentController): Router {
+  const router = Router();
+
+  router.post('/', controller.create.bind(controller));
+  router.get('/', controller.list.bind(controller));
+  router.get('/:id', controller.getById.bind(controller));
+  router.put('/:id', controller.update.bind(controller));
+  router.delete('/:id', controller.remove.bind(controller));
+
+  return router;
+}

--- a/packages/incident-service/src/app.ts
+++ b/packages/incident-service/src/app.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import compression from 'compression';
+import { IncidentService } from './services/incident.service';
+import { IncidentController } from './api/controllers/incident.controller';
+import { createIncidentRoutes } from './api/routes/incident.routes';
+
+export const incidentService = new IncidentService();
+const incidentController = new IncidentController(incidentService);
+
+const app = express();
+app.use(express.json());
+app.use(cors());
+app.use(helmet());
+app.use(compression());
+
+app.use('/api/incidents', createIncidentRoutes(incidentController));
+
+export default app;

--- a/packages/incident-service/src/index.ts
+++ b/packages/incident-service/src/index.ts
@@ -1,0 +1,7 @@
+import app from './app';
+
+const port = process.env.PORT || 3010;
+
+app.listen(port, () => {
+  console.log(`Incident service running on port ${port}`);
+});

--- a/packages/incident-service/src/services/incident.service.ts
+++ b/packages/incident-service/src/services/incident.service.ts
@@ -1,0 +1,48 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export interface Incident {
+  id: string;
+  userId: string;
+  routeId: string;
+  type: string;
+  severity: string;
+  notes: string;
+  timestamp: Date;
+  status: string;
+}
+
+export class IncidentService {
+  private incidents: Incident[] = [];
+
+  async createIncident(data: Omit<Incident, 'id' | 'timestamp'>): Promise<Incident> {
+    const incident: Incident = {
+      ...data,
+      id: uuidv4(),
+      timestamp: new Date(),
+    };
+    this.incidents.push(incident);
+    return incident;
+  }
+
+  async getIncident(id: string): Promise<Incident | undefined> {
+    return this.incidents.find((i) => i.id === id);
+  }
+
+  async listIncidents(): Promise<Incident[]> {
+    return this.incidents;
+  }
+
+  async updateIncident(id: string, updates: Partial<Incident>): Promise<Incident | undefined> {
+    const incident = await this.getIncident(id);
+    if (!incident) return undefined;
+    Object.assign(incident, updates);
+    return incident;
+  }
+
+  async deleteIncident(id: string): Promise<boolean> {
+    const index = this.incidents.findIndex((i) => i.id === id);
+    if (index === -1) return false;
+    this.incidents.splice(index, 1);
+    return true;
+  }
+}

--- a/packages/incident-service/tsconfig.json
+++ b/packages/incident-service/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": "./src",
+    "paths": {
+      "@shared/*": ["../../shared/src/*"],
+      "@send/shared": ["../../shared/src"],
+      "@send/shared/*": ["../../shared/src/*"]
+    },
+    "types": ["node", "jest", "express"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/invoicing-service/jest.config.js
+++ b/packages/invoicing-service/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  moduleNameMapper: {
+    '^@send/shared$': '<rootDir>/../shared/src',
+    '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
+    '^@shared/(.*)$': '<rootDir>/../shared/src/$1'
+  }
+};

--- a/packages/invoicing-service/package.json
+++ b/packages/invoicing-service/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "invoicing-service",
+  "version": "1.0.0",
+  "description": "Invoice generation and management service",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "nodemon src/index.ts",
+    "test": "jest",
+    "lint": "eslint src/**/*.ts",
+    "format": "prettier --write \"src/**/*.ts\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.24",
+    "@typescript-eslint/eslint-plugin": "^7.0.1",
+    "@typescript-eslint/parser": "^7.0.1",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "jest": "^29.7.0",
+    "nodemon": "^3.0.3",
+    "prettier": "^3.2.5",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/invoicing-service/src/api/controllers/invoice.controller.ts
+++ b/packages/invoicing-service/src/api/controllers/invoice.controller.ts
@@ -1,0 +1,37 @@
+import { Request, Response } from 'express';
+import { InvoiceService } from '../../services/invoice.service';
+
+export class InvoiceController {
+  constructor(private readonly invoiceService: InvoiceService) {}
+
+  async create(req: Request, res: Response): Promise<void> {
+    try {
+      const invoice = await this.invoiceService.createInvoice(req.body);
+      res.status(201).json(invoice);
+    } catch (err) {
+      res.status(500).json({ error: 'Failed to create invoice' });
+    }
+  }
+
+  async list(req: Request, res: Response): Promise<void> {
+    res.json(await this.invoiceService.listInvoices());
+  }
+
+  async getById(req: Request, res: Response): Promise<void> {
+    const invoice = await this.invoiceService.getInvoice(req.params.id);
+    if (!invoice) {
+      res.status(404).json({ error: 'Invoice not found' });
+      return;
+    }
+    res.json(invoice);
+  }
+
+  async updateStatus(req: Request, res: Response): Promise<void> {
+    const invoice = await this.invoiceService.updateInvoiceStatus(req.params.id, req.body.status);
+    if (!invoice) {
+      res.status(404).json({ error: 'Invoice not found' });
+      return;
+    }
+    res.json(invoice);
+  }
+}

--- a/packages/invoicing-service/src/api/routes/invoice.routes.ts
+++ b/packages/invoicing-service/src/api/routes/invoice.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { InvoiceController } from '../controllers/invoice.controller';
+
+export function createInvoiceRoutes(controller: InvoiceController): Router {
+  const router = Router();
+
+  router.post('/', controller.create.bind(controller));
+  router.get('/', controller.list.bind(controller));
+  router.get('/:id', controller.getById.bind(controller));
+  router.put('/:id/status', controller.updateStatus.bind(controller));
+
+  return router;
+}

--- a/packages/invoicing-service/src/app.ts
+++ b/packages/invoicing-service/src/app.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import compression from 'compression';
+import { InvoiceService } from './services/invoice.service';
+import { InvoiceController } from './api/controllers/invoice.controller';
+import { createInvoiceRoutes } from './api/routes/invoice.routes';
+
+export const invoiceService = new InvoiceService();
+const invoiceController = new InvoiceController(invoiceService);
+
+const app = express();
+app.use(express.json());
+app.use(cors());
+app.use(helmet());
+app.use(compression());
+
+app.use('/api/invoices', createInvoiceRoutes(invoiceController));
+
+export default app;

--- a/packages/invoicing-service/src/index.ts
+++ b/packages/invoicing-service/src/index.ts
@@ -1,0 +1,7 @@
+import app from './app';
+
+const port = process.env.PORT || 3011;
+
+app.listen(port, () => {
+  console.log(`Invoicing service running on port ${port}`);
+});

--- a/packages/invoicing-service/src/services/invoice.service.ts
+++ b/packages/invoicing-service/src/services/invoice.service.ts
@@ -1,0 +1,39 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export interface Invoice {
+  id: string;
+  routeId: string;
+  amount: number;
+  status: string;
+  issuedAt: Date;
+  dueAt: Date;
+}
+
+export class InvoiceService {
+  private invoices: Invoice[] = [];
+
+  async createInvoice(data: Omit<Invoice, 'id' | 'issuedAt'>): Promise<Invoice> {
+    const invoice: Invoice = {
+      ...data,
+      id: uuidv4(),
+      issuedAt: new Date(),
+    };
+    this.invoices.push(invoice);
+    return invoice;
+  }
+
+  async listInvoices(): Promise<Invoice[]> {
+    return this.invoices;
+  }
+
+  async getInvoice(id: string): Promise<Invoice | undefined> {
+    return this.invoices.find((i) => i.id === id);
+  }
+
+  async updateInvoiceStatus(id: string, status: string): Promise<Invoice | undefined> {
+    const invoice = await this.getInvoice(id);
+    if (!invoice) return undefined;
+    invoice.status = status;
+    return invoice;
+  }
+}

--- a/packages/invoicing-service/tsconfig.json
+++ b/packages/invoicing-service/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": "./src",
+    "paths": {
+      "@shared/*": ["../../shared/src/*"],
+      "@send/shared": ["../../shared/src"],
+      "@send/shared/*": ["../../shared/src/*"]
+    },
+    "types": ["node", "jest", "express"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add new incident, invoicing, and admin services with basic Express APIs
- register new services in the API gateway
- list new services in README

## Testing
- `pnpm run test` *(fails: needs interactive Prisma install)*

------
https://chatgpt.com/codex/tasks/task_e_6841cb3004cc83339e52d691e2bcce2f