### PR TITLE
Fix import for Run type in driver service

### DIFF
--- a/packages/driver-service/src/services/driver.service.ts
+++ b/packages/driver-service/src/services/driver.service.ts
@@ -1,4 +1,5 @@
-import { PrismaClient, Prisma, Run } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
+import { Run } from '@shared/types/run';
 import { Driver, DriverStatus } from '@shared/types/driver';
 import { RabbitMQService } from './messaging/rabbitmq.service';
 


### PR DESCRIPTION
## Summary
- fix Run import path in driver service

## Testing
- `npx ts-node --transpile-only -r tsconfig-paths/register -P packages/driver-service/tsconfig.json packages/driver-service/src/services/driver.service.ts`
- `npm --workspace packages/driver-service test` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*

------
https://chatgpt.com/codex/tasks/task_e_6841d8c9cd6483338e2977651ab04a7b