### PR TITLE
Fix redis mocking in vehicle tests

### DIFF
--- a/packages/vehicle-service/src/__tests__/services/vehicle.additional.test.ts
+++ b/packages/vehicle-service/src/__tests__/services/vehicle.additional.test.ts
@@ -9,6 +9,7 @@ describe('VehicleService additional methods', () => {
     prisma = { $queryRaw: jest.fn() } as any;
     service = new VehicleService();
     (service as any).prisma = prisma;
+    (service as any).redis = { get: jest.fn(), set: jest.fn(), del: jest.fn() };
   });
 
   it('assignVehicleToRun should update run and status', async () => {


### PR DESCRIPTION
## Summary
- mock Redis in vehicle.additional.test beforeEach to avoid real network calls

## Testing
- `npx jest src/__tests__/services/vehicle.additional.test.ts --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6841d8cf4b948333bf3babc0533532a9