### PR TITLE
Set DATABASE_URL in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ pnpm run dev        # start all services in dev mode
 pnpm run test       # run tests across packages
 ```
 
+## Running Tests
+
+Tests require a PostgreSQL database. The helper in `shared/src/testing/setup.ts`
+sets `process.env.DATABASE_URL` to
+`postgresql://user:password@localhost:5432/send_test?schema=public` if the
+variable is undefined. You can override this by defining `DATABASE_URL` in your
+environment before running `pnpm run test`.
+
 ## License
 
 This project is licensed under the MIT License.

--- a/packages/shared/src/testing/setup.ts
+++ b/packages/shared/src/testing/setup.ts
@@ -5,6 +5,11 @@ import { AddressInfo } from 'net';
 import { promisify } from 'util';
 import { exec } from 'child_process';
 
+// Ensure Prisma has a database connection during tests
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  'postgresql://user:password@localhost:5432/send_test?schema=public';
+
 const execAsync = promisify(exec);
 
 export class TestSetup {


### PR DESCRIPTION
## Summary
- set default `DATABASE_URL` in shared test setup
- document DATABASE_URL requirement for running tests

## Testing
- `npm test` *(fails: driver-service tasks)*

------
https://chatgpt.com/codex/tasks/task_e_6841d8d28b5c833383aa579cfc362f20