### PR TITLE
Add document expiry cron job and update endpoints

### DIFF
--- a/packages/document-service/package.json
+++ b/packages/document-service/package.json
@@ -17,8 +17,9 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
-    "shared": "workspace:*",
     "express": "^4.18.2",
+    "node-cron": "^4.1.0",
+    "shared": "workspace:*",
     "winston": "^3.11.0"
   },
   "devDependencies": {

--- a/packages/document-service/src/api/controllers/document.controller.ts
+++ b/packages/document-service/src/api/controllers/document.controller.ts
@@ -65,4 +65,34 @@ export class DocumentController {
       res.status(500).json({ error: 'Failed to delete document' });
     }
   }
+
+  async updateDocumentAccess(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const { userId, permission, grantedBy, expiresAt } = req.body;
+      const access = await this.documentService.updateDocumentAccess(
+        id,
+        userId,
+        permission,
+        grantedBy,
+        expiresAt ? new Date(expiresAt) : undefined
+      );
+      res.json(access);
+    } catch (error) {
+      console.error('Failed to update document access:', error);
+      res.status(500).json({ error: 'Failed to update document access' });
+    }
+  }
+
+  async updateDocumentMetadata(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const metadata = req.body.metadata;
+      const doc = await this.documentService.updateDocumentMetadata(id, metadata);
+      res.json(doc);
+    } catch (error) {
+      console.error('Failed to update document metadata:', error);
+      res.status(500).json({ error: 'Failed to update document metadata' });
+    }
+  }
 }

--- a/packages/document-service/src/api/routes/document.routes.ts
+++ b/packages/document-service/src/api/routes/document.routes.ts
@@ -10,6 +10,8 @@ export function createDocumentRoutes(controller: DocumentController): Router {
   router.get('/', controller.listDocuments.bind(controller));
   router.get('/:id', controller.getDocumentById.bind(controller));
   router.delete('/:id', controller.deleteDocument.bind(controller));
+  router.patch('/:id/access', controller.updateDocumentAccess.bind(controller));
+  router.patch('/:id/metadata', controller.updateDocumentMetadata.bind(controller));
 
   return router;
 }

--- a/packages/document-service/src/app.ts
+++ b/packages/document-service/src/app.ts
@@ -65,4 +65,4 @@ app.use((err: any, req: express.Request, res: express.Response, next: express.Ne
   });
 });
 
-export { app, prisma, rabbitMQ, logger }; 
+export { app, prisma, rabbitMQ, logger, documentService };

--- a/packages/document-service/src/index.ts
+++ b/packages/document-service/src/index.ts
@@ -1,10 +1,12 @@
-import { app, prisma, rabbitMQ, logger } from './app';
+import { app, prisma, rabbitMQ, logger, documentService } from './app';
+import { startExpirationJob } from './jobs/expire-documents';
 
 const port = process.env.PORT || 3006;
 
 async function start() {
   try {
     await rabbitMQ.connect();
+    startExpirationJob(documentService);
     app.listen(port, () => {
       console.log(`Document service running on port ${port}`);
     });

--- a/packages/document-service/src/jobs/expire-documents.ts
+++ b/packages/document-service/src/jobs/expire-documents.ts
@@ -1,0 +1,9 @@
+import cron from 'node-cron';
+import { DocumentService } from '../services/document.service';
+
+export function startExpirationJob(documentService: DocumentService): void {
+  // run every hour
+  cron.schedule('0 * * * *', async () => {
+    await documentService.expireOutdatedDocuments();
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.21.2
+      node-cron:
+        specifier: ^4.1.0
+        version: 4.1.0
       shared:
         specifier: workspace:*
         version: link:../shared
@@ -734,6 +737,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.21.2
+      ioredis:
+        specifier: ^5.3.2
+        version: 5.6.1
       multer:
         specifier: ^1.4.5-lts.1
         version: 1.4.5-lts.2
@@ -5157,6 +5163,10 @@ packages:
 
   node-addon-api@5.1.0:
     resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
+
+  node-cron@4.1.0:
+    resolution: {integrity: sha512-OS+3ORu+h03/haS6Di8Qr7CrVs4YaKZZOynZwQpyPZDnR3tqRbwJmuP2gVR16JfhLgyNlloAV1VTrrWlRogCFA==}
+    engines: {node: '>=6.0.0'}
 
   node-emoji@1.11.0:
     resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
@@ -12494,6 +12504,8 @@ snapshots:
   node-addon-api@3.2.1: {}
 
   node-addon-api@5.1.0: {}
+
+  node-cron@4.1.0: {}
 
   node-emoji@1.11.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add node-cron job to expire documents automatically
- publish RabbitMQ events when documents expire or metadata updates
- expose update metadata and update access endpoints
- wire cron job into service startup
- add tests for new service functions

## Testing
- `pnpm --filter ./packages/document-service test`

------
https://chatgpt.com/codex/tasks/task_e_6841d8ea2c688333ab1390407d12f66c