### PR TITLE
Add new service proxies to API Gateway

### DIFF
--- a/packages/api-gateway/README.md
+++ b/packages/api-gateway/README.md
@@ -13,6 +13,10 @@ traffic to the underlying services and enforces authentication using the shared
 - `DRIVER_SERVICE_URL` - URL of the driver service (default: `http://localhost:3004`)
 - `VEHICLE_SERVICE_URL` - URL of the vehicle service (default: `http://localhost:3005`)
 - `DOCUMENT_SERVICE_URL` - URL of the document service (default: `http://localhost:3006`)
+- `TRACKING_SERVICE_URL` - URL of the tracking service (default: `http://localhost:3007`)
+- `INCIDENT_SERVICE_URL` - URL of the incident service (default: `http://localhost:3008`)
+- `INVOICING_SERVICE_URL` - URL of the invoicing service (default: `http://localhost:3009`)
+- `ADMIN_DASHBOARD_SERVICE_URL` - URL of the admin dashboard service (default: `http://localhost:3010`)
 
 ## Development
 

--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -21,5 +21,9 @@ app.use('/api/students', createProxyMiddleware({ target: serviceConfig.studentSe
 app.use('/api/drivers', createProxyMiddleware({ target: serviceConfig.driverService, changeOrigin: true }));
 app.use('/api/vehicles', createProxyMiddleware({ target: serviceConfig.vehicleService, changeOrigin: true }));
 app.use('/api/documents', createProxyMiddleware({ target: serviceConfig.documentService, changeOrigin: true }));
+app.use('/api/tracking', createProxyMiddleware({ target: serviceConfig.trackingService, changeOrigin: true }));
+app.use('/api/incidents', createProxyMiddleware({ target: serviceConfig.incidentService, changeOrigin: true }));
+app.use('/api/invoices', createProxyMiddleware({ target: serviceConfig.invoicingService, changeOrigin: true }));
+app.use('/api/admin-dashboard', createProxyMiddleware({ target: serviceConfig.adminDashboardService, changeOrigin: true }));
 
 export default app;

--- a/packages/api-gateway/src/config.ts
+++ b/packages/api-gateway/src/config.ts
@@ -4,5 +4,11 @@ export const serviceConfig = {
   studentService: process.env.STUDENT_SERVICE_URL || 'http://localhost:3003',
   driverService: process.env.DRIVER_SERVICE_URL || 'http://localhost:3004',
   vehicleService: process.env.VEHICLE_SERVICE_URL || 'http://localhost:3005',
-  documentService: process.env.DOCUMENT_SERVICE_URL || 'http://localhost:3006'
+  documentService: process.env.DOCUMENT_SERVICE_URL || 'http://localhost:3006',
+  trackingService: process.env.TRACKING_SERVICE_URL || 'http://localhost:3007',
+  incidentService: process.env.INCIDENT_SERVICE_URL || 'http://localhost:3008',
+  invoicingService:
+    process.env.INVOICING_SERVICE_URL || 'http://localhost:3009',
+  adminDashboardService:
+    process.env.ADMIN_DASHBOARD_SERVICE_URL || 'http://localhost:3010'
 };


### PR DESCRIPTION
## Summary
- extend `serviceConfig` with tracking, incident, invoicing and admin dashboard services
- add proxy middleware for the new services
- document new service URLs in the API Gateway README

## Testing
- `pnpm --filter api-gateway test`
- `pnpm lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6841d8ec26d08333a627a55b2da0b148