### PR TITLE
Fix driver-service test compilation

### DIFF
--- a/packages/driver-service/jest.config.js
+++ b/packages/driver-service/jest.config.js
@@ -10,6 +10,12 @@ module.exports = {
     '^@send/shared$': '<rootDir>/../shared/src',
     '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
     '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
+    '^@prisma/client$': '<rootDir>/../../test/prisma-client.ts'
+  },
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.test.json'
+    }
   },
   coverageDirectory: 'coverage',
   collectCoverageFrom: [

--- a/packages/driver-service/tsconfig.json
+++ b/packages/driver-service/tsconfig.json
@@ -3,16 +3,16 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "../../",
-    "baseUrl": "./src",
+    "baseUrl": ".",
     "paths": {
       "@services/*": ["./services/*"],
       "@types/*": ["./types/*"],
-      "@shared/*": ["../../shared/src/*"],
-      "@send/shared": ["../../shared/src"],
-      "@send/shared/*": ["../../shared/src/*"]
+      "@shared/*": ["../shared/src/*"],
+      "@send/shared": ["../shared/src"],
+      "@send/shared/*": ["../shared/src/*"]
     },
     "types": ["node", "jest", "express"]
   },
-  "include": ["src/**/*.ts", "../shared/src/**/*.ts"],
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 } 

--- a/packages/driver-service/tsconfig.test.json
+++ b/packages/driver-service/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@services/*": ["./src/services/*"],
+      "@types/*": ["./src/types/*"],
+      "@shared/*": ["../shared/src/*"],
+      "@send/shared": ["../shared/src"],
+      "@send/shared/*": ["../shared/src/*"],
+      "@prisma/client": ["../../test/prisma-client.ts"]
+    }
+  }
+  ,
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/shared/src/types/run.ts
+++ b/packages/shared/src/types/run.ts
@@ -38,6 +38,9 @@ export interface Run {
   studentIds: string[];
   routeId?: string;
   notes?: string;
+  scheduledStartTime?: Date;
+  actualStartTime?: Date;
+  rating?: number;
   createdAt: Date;
   updatedAt: Date;
 


### PR DESCRIPTION
## Summary
- add scheduling and rating fields to shared Run type
- configure driver-service tests to use prisma stub
- adjust TypeScript configs for driver-service

## Testing
- `npm test -w packages/driver-service --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841e0765de88333ab3d197f6146ba0d