### PR TITLE
Add password reset endpoints to user service

### DIFF
--- a/packages/user-service/README.md
+++ b/packages/user-service/README.md
@@ -17,6 +17,8 @@ The User Service is a microservice responsible for user management in the SEND T
 - `POST /api/auth/login` - User login
 - `POST /api/auth/register` - User registration
 - `POST /api/auth/refresh-token` - Refresh JWT token
+- `POST /api/users/password/reset-request` - Request password reset
+- `POST /api/users/password/reset` - Reset password
 
 ### User Management
 - `GET /api/users/profile` - Get user profile

--- a/packages/user-service/prisma/schema.prisma
+++ b/packages/user-service/prisma/schema.prisma
@@ -36,6 +36,7 @@ model User {
   driver   Driver?
   pa       Pa?
   guardian Guardian?
+  passwordResetTokens PasswordResetToken[]
 
   @@map("users")
 }
@@ -93,3 +94,13 @@ model Child {
 
   @@map("children")
 } 
+model PasswordResetToken {
+  id        String   @id @default(uuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id])
+  token     String   @unique
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+
+  @@map("password_reset_tokens")
+}

--- a/packages/user-service/src/api/routes/user.routes.ts
+++ b/packages/user-service/src/api/routes/user.routes.ts
@@ -8,6 +8,8 @@ const router = Router();
 // Public routes
 router.post('/register', UserController.register);
 router.post('/login', UserController.login);
+router.post('/password/reset-request', UserController.requestPasswordReset);
+router.post('/password/reset', UserController.resetPassword);
 
 // Protected routes
 router.get('/profile', authenticate, UserController.getProfile);

--- a/packages/user-service/src/data/models/passwordResetToken.model.ts
+++ b/packages/user-service/src/data/models/passwordResetToken.model.ts
@@ -1,0 +1,22 @@
+import { PrismaClient } from '../../../prisma/generated/client';
+
+const prisma = new PrismaClient();
+
+export const PasswordResetTokenModel = {
+  async create(data: { userId: string; token: string; expiresAt: Date }) {
+    return prisma.passwordResetToken.create({ data });
+  },
+
+  async findByToken(token: string) {
+    return prisma.passwordResetToken.findFirst({
+      where: {
+        token,
+        expiresAt: { gt: new Date() }
+      }
+    });
+  },
+
+  async delete(id: string) {
+    return prisma.passwordResetToken.delete({ where: { id } });
+  }
+};


### PR DESCRIPTION
## Summary
- implement password reset token model
- support requestPasswordReset and resetPassword in controller
- expose new password reset routes
- send email notifications via notification service
- document new endpoints in user service README

## Testing
- `pnpm test` *(fails: Lerna running targets for multiple projects failed)*

------
https://chatgpt.com/codex/tasks/task_e_6841e63b30ac83339f803f69af248843