### PR TITLE
Add persistent incident model with escalation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "build": "lerna run build",
-    "generate:prisma": "npx prisma generate --schema=packages/driver-service/prisma/schema.prisma && npx prisma generate --schema=packages/run-service/prisma/schema.prisma && npx prisma generate --schema=packages/system-notification-service/prisma/schema.prisma && npx prisma generate --schema=packages/user-service/prisma/schema.prisma && npx prisma generate --schema=packages/vehicle-service/prisma/schema.prisma && npx prisma generate --schema=packages/student-service/prisma/schema.prisma && npx prisma generate --schema=packages/document-service/prisma/schema.prisma && npx prisma generate --schema=packages/tracking-service/prisma/schema.prisma",
+    "generate:prisma": "npx prisma generate --schema=packages/driver-service/prisma/schema.prisma && npx prisma generate --schema=packages/run-service/prisma/schema.prisma && npx prisma generate --schema=packages/system-notification-service/prisma/schema.prisma && npx prisma generate --schema=packages/user-service/prisma/schema.prisma && npx prisma generate --schema=packages/vehicle-service/prisma/schema.prisma && npx prisma generate --schema=packages/student-service/prisma/schema.prisma && npx prisma generate --schema=packages/document-service/prisma/schema.prisma && npx prisma generate --schema=packages/tracking-service/prisma/schema.prisma && npx prisma generate --schema=packages/incident-service/prisma/schema.prisma",
     "test": "npm run generate:prisma && lerna run test",
     "lint": "lerna run lint",
     "format": "lerna run format",

--- a/packages/incident-service/package.json
+++ b/packages/incident-service/package.json
@@ -10,11 +10,17 @@
     "dev": "nodemon src/index.ts",
     "test": "jest",
     "lint": "eslint src/**/*.ts",
-    "format": "prettier --write \"src/**/*.ts\""
+    "format": "prettier --write \"src/**/*.ts\"",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "prisma:studio": "prisma studio"
   },
   "dependencies": {
     "express": "^4.18.2",
-    "shared": "workspace:*"
+    "shared": "workspace:*",
+    "@prisma/client": "^5.22.0",
+    "node-cron": "^4.1.0",
+    "winston": "^3.11.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
@@ -30,7 +36,10 @@
     "prettier": "^3.2.5",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "prisma": "^5.22.0",
+    "supertest": "^6.3.4",
+    "@types/supertest": "^6.0.2"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/incident-service/prisma/schema.prisma
+++ b/packages/incident-service/prisma/schema.prisma
@@ -1,0 +1,20 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Incident {
+  id        String   @id @default(uuid())
+  userId    String
+  routeId   String
+  type      String
+  severity  String
+  notes     String
+  timestamp DateTime @default(now())
+  status    String
+  escalated Boolean  @default(false)
+}

--- a/packages/incident-service/src/__tests__/controllers/incident.controller.test.ts
+++ b/packages/incident-service/src/__tests__/controllers/incident.controller.test.ts
@@ -1,0 +1,64 @@
+import request from 'supertest';
+import express from 'express';
+import { IncidentController } from '../../api/controllers/incident.controller';
+import { IncidentService } from '../../services/incident.service';
+
+describe('IncidentController', () => {
+  let app: express.Application;
+  let service: jest.Mocked<IncidentService>;
+  let controller: IncidentController;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+
+    service = {
+      createIncident: jest.fn(),
+      listIncidents: jest.fn(),
+      getIncident: jest.fn(),
+      updateIncident: jest.fn(),
+      deleteIncident: jest.fn(),
+      findUnescalatedHighSeverity: jest.fn(),
+      markEscalated: jest.fn()
+    } as unknown as jest.Mocked<IncidentService>;
+
+    controller = new IncidentController(service);
+    app.post('/incidents', (req, res) => controller.create(req, res));
+    app.put('/incidents/:id', (req, res) => controller.update(req, res));
+  });
+
+  it('should create an incident', async () => {
+    const incident = { id: '1', userId: 'u1', routeId: 'r1', type: 'TYPE', severity: 'LOW', notes: '', timestamp: new Date(), status: 'OPEN', escalated: false };
+    service.createIncident.mockResolvedValue(incident);
+
+    const res = await request(app).post('/incidents').send({ userId: 'u1', routeId: 'r1', type: 'TYPE', severity: 'LOW', notes: '', status: 'OPEN' });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      id: '1',
+      userId: 'u1',
+      routeId: 'r1',
+      type: 'TYPE',
+      severity: 'LOW',
+      notes: '',
+      status: 'OPEN',
+      escalated: false
+    });
+    expect(res.body).toHaveProperty('timestamp');
+    expect(service.createIncident).toHaveBeenCalled();
+  });
+
+  it('should update an incident', async () => {
+    const updated = { id: '1', userId: 'u1', routeId: 'r1', type: 'TYPE', severity: 'LOW', notes: 'n', timestamp: new Date(), status: 'OPEN', escalated: false };
+    service.updateIncident.mockResolvedValue(updated);
+
+    const res = await request(app).put('/incidents/1').send({ notes: 'n' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      id: '1',
+      notes: 'n'
+    });
+    expect(service.updateIncident).toHaveBeenCalledWith('1', { notes: 'n' });
+  });
+});

--- a/packages/incident-service/src/__tests__/jobs/escalation.job.test.ts
+++ b/packages/incident-service/src/__tests__/jobs/escalation.job.test.ts
@@ -1,0 +1,22 @@
+import { startEscalationJob } from '../../jobs/escalation.job';
+import { IncidentService } from '../../services/incident.service';
+import { RabbitMQService } from '@shared/messaging/rabbitmq.service';
+import cron from 'node-cron';
+
+jest.mock('node-cron');
+
+const scheduleMock = cron.schedule as jest.Mock;
+
+describe('startEscalationJob', () => {
+  it('schedules escalation checks', () => {
+    const service = {
+      findUnescalatedHighSeverity: jest.fn().mockResolvedValue([]),
+      markEscalated: jest.fn()
+    } as unknown as IncidentService;
+    const rabbit = { publishMessage: jest.fn() } as unknown as RabbitMQService;
+
+    startEscalationJob(service, rabbit);
+
+    expect(scheduleMock).toHaveBeenCalled();
+  });
+});

--- a/packages/incident-service/src/index.ts
+++ b/packages/incident-service/src/index.ts
@@ -1,7 +1,23 @@
-import app from './app';
+import { app, rabbitMQ, prisma, logger } from './app';
 
 const port = process.env.PORT || 3010;
 
-app.listen(port, () => {
-  console.log(`Incident service running on port ${port}`);
+async function start() {
+  try {
+    await rabbitMQ.connect();
+    app.listen(port, () => {
+      console.log(`Incident service running on port ${port}`);
+    });
+  } catch (err) {
+    logger.error('Failed to start incident service', { error: err });
+    process.exit(1);
+  }
+}
+
+start();
+
+process.on('SIGTERM', async () => {
+  await rabbitMQ.close();
+  await prisma.$disconnect();
+  process.exit(0);
 });

--- a/packages/incident-service/src/jobs/escalation.job.ts
+++ b/packages/incident-service/src/jobs/escalation.job.ts
@@ -1,0 +1,13 @@
+import cron from 'node-cron';
+import { IncidentService } from '../services/incident.service';
+import { RabbitMQService } from '@shared/messaging/rabbitmq.service';
+
+export function startEscalationJob(service: IncidentService, rabbit: RabbitMQService): void {
+  cron.schedule('*/5 * * * *', async () => {
+    const incidents = await service.findUnescalatedHighSeverity();
+    for (const incident of incidents) {
+      await rabbit.publishMessage('IncidentEscalation', incident);
+      await service.markEscalated(incident.id);
+    }
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,58 @@ importers:
         specifier: ^6.6.2
         version: 6.6.2(encoding@0.1.13)
 
+  packages/admin-service:
+    dependencies:
+      express:
+        specifier: ^4.18.2
+        version: 4.21.2
+      shared:
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.21
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.11.24
+        version: 20.17.30
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.0.1
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.0.1
+        version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@8.57.1)
+      eslint-plugin-prettier:
+        specifier: ^5.1.3
+        version: 5.2.6(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.5.3)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.17.30)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3))
+      nodemon:
+        specifier: ^3.0.3
+        version: 3.1.9
+      prettier:
+        specifier: ^3.2.5
+        version: 3.5.3
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.3.1(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.30)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3)))(typescript@5.8.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.17.30)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+
   packages/api-gateway:
     dependencies:
       express:
@@ -142,6 +194,110 @@ importers:
       winston:
         specifier: ^3.11.0
         version: 3.17.0
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.21
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.11.24
+        version: 20.17.30
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.0.1
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.0.1
+        version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@8.57.1)
+      eslint-plugin-prettier:
+        specifier: ^5.1.3
+        version: 5.2.6(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.5.3)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.17.30)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3))
+      nodemon:
+        specifier: ^3.0.3
+        version: 3.1.9
+      prettier:
+        specifier: ^3.2.5
+        version: 3.5.3
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.3.1(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.30)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3)))(typescript@5.8.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.17.30)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+
+  packages/incident-service:
+    dependencies:
+      express:
+        specifier: ^4.18.2
+        version: 4.21.2
+      shared:
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.21
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.11.24
+        version: 20.17.30
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.0.1
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.0.1
+        version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@8.57.1)
+      eslint-plugin-prettier:
+        specifier: ^5.1.3
+        version: 5.2.6(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.5.3)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.17.30)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3))
+      nodemon:
+        specifier: ^3.0.3
+        version: 3.1.9
+      prettier:
+        specifier: ^3.2.5
+        version: 3.5.3
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.3.1(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.30)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3)))(typescript@5.8.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.17.30)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+
+  packages/invoicing-service:
+    dependencies:
+      express:
+        specifier: ^4.18.2
+        version: 4.21.2
+      shared:
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       '@types/express':
         specifier: ^4.17.21


### PR DESCRIPTION
## Summary
- add Prisma schema for incidents
- integrate Prisma into incident service and add escalation job
- run escalation job on startup and connect RabbitMQ
- update root prisma generation
- provide basic tests for controller and job

## Testing
- `npx lerna run test --scope incident-service`

------
https://chatgpt.com/codex/tasks/task_e_6841eafba4c08333860a8acddd420c5e