### PR TITLE
Add metrics aggregation and tenant config

### DIFF
--- a/packages/admin-service/README.md
+++ b/packages/admin-service/README.md
@@ -7,11 +7,14 @@ The Admin Service powers the administrative dashboard for SEND Dispatch, aggrega
 - Provide operational metrics (runs today, on-time percentage, open incidents)
 - Generate summary reports for analysis
 - Expose REST endpoints for dashboard widgets
+- Manage tenant level configuration
 
 ## API Endpoints
 
 - `GET /api/admin/metrics` - Get high level system metrics
 - `GET /api/admin/reports` - Retrieve generated reports
+- `GET /api/admin/config` - Retrieve tenant configuration
+- `PUT /api/admin/config` - Update tenant configuration
 
 ## Installation
 

--- a/packages/admin-service/package.json
+++ b/packages/admin-service/package.json
@@ -14,7 +14,9 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "shared": "workspace:*"
+    "shared": "workspace:*",
+    "@prisma/client": "^5.22.0",
+    "amqplib": "^0.10.7"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/admin-service/src/api/controllers/admin.controller.ts
+++ b/packages/admin-service/src/api/controllers/admin.controller.ts
@@ -1,16 +1,29 @@
 import { Request, Response } from 'express';
+import { MetricsService } from '../../services/metrics.service';
+import { ConfigService } from '../../services/config.service';
 
 export class AdminController {
+  constructor(
+    private readonly metricsService: MetricsService,
+    private readonly configService: ConfigService
+  ) {}
+
   async metrics(req: Request, res: Response): Promise<void> {
-    res.json({
-      totalRunsToday: 0,
-      onTimePercentage: 0,
-      openIncidents: 0,
-      expiringDocuments: 0
-    });
+    const metrics = await this.metricsService.getMetrics();
+    res.json(metrics);
   }
 
   async reports(req: Request, res: Response): Promise<void> {
     res.json([]);
+  }
+
+  async getConfig(req: Request, res: Response): Promise<void> {
+    const config = await this.configService.getConfig();
+    res.json(config);
+  }
+
+  async updateConfig(req: Request, res: Response): Promise<void> {
+    const config = await this.configService.updateConfig(req.body);
+    res.json(config);
   }
 }

--- a/packages/admin-service/src/api/routes/admin.routes.ts
+++ b/packages/admin-service/src/api/routes/admin.routes.ts
@@ -6,6 +6,8 @@ export function createAdminRoutes(controller: AdminController): Router {
 
   router.get('/admin/metrics', controller.metrics.bind(controller));
   router.get('/admin/reports', controller.reports.bind(controller));
+  router.get('/admin/config', controller.getConfig.bind(controller));
+  router.put('/admin/config', controller.updateConfig.bind(controller));
 
   return router;
 }

--- a/packages/admin-service/src/app.ts
+++ b/packages/admin-service/src/app.ts
@@ -4,8 +4,12 @@ import helmet from 'helmet';
 import compression from 'compression';
 import { AdminController } from './api/controllers/admin.controller';
 import { createAdminRoutes } from './api/routes/admin.routes';
+import { MetricsService } from './services/metrics.service';
+import { ConfigService } from './services/config.service';
 
-const controller = new AdminController();
+const metricsService = new MetricsService();
+const configService = new ConfigService();
+const controller = new AdminController(metricsService, configService);
 
 const app = express();
 app.use(express.json());

--- a/packages/admin-service/src/services/config.service.ts
+++ b/packages/admin-service/src/services/config.service.ts
@@ -1,0 +1,16 @@
+export interface TenantConfig {
+  [key: string]: any;
+}
+
+export class ConfigService {
+  private config: TenantConfig = {};
+
+  async getConfig(): Promise<TenantConfig> {
+    return this.config;
+  }
+
+  async updateConfig(updates: TenantConfig): Promise<TenantConfig> {
+    this.config = { ...this.config, ...updates };
+    return this.config;
+  }
+}

--- a/packages/admin-service/src/services/metrics.service.ts
+++ b/packages/admin-service/src/services/metrics.service.ts
@@ -1,0 +1,67 @@
+import { PrismaClient } from '@prisma/client';
+import { RabbitMQService } from 'shared/src/messaging/rabbitmq.service';
+import { LoggingService } from 'shared/src/services/logging.service';
+
+interface Metrics {
+  totalRunsToday: number;
+  onTimePercentage: number;
+  openIncidents: number;
+  expiringDocuments: number;
+}
+
+export class MetricsService {
+  private runDb: PrismaClient;
+  private documentDb: PrismaClient;
+  private openIncidents = 0;
+  private rabbit: RabbitMQService;
+  private logger = new LoggingService('admin-service');
+
+  constructor() {
+    this.runDb = new PrismaClient({
+      datasources: { db: { url: process.env.RUN_DATABASE_URL! } }
+    });
+    this.documentDb = new PrismaClient({
+      datasources: { db: { url: process.env.DOCUMENT_DATABASE_URL! } }
+    });
+
+    this.rabbit = new RabbitMQService(
+      {
+        url: process.env.RABBITMQ_URL || 'amqp://localhost',
+        exchange: 'incidents',
+        queue: 'admin-metrics'
+      },
+      this.logger
+    );
+
+    this.rabbit.connect().then(() => {
+      this.rabbit.consumeMessages(async (msg: any) => {
+        if (msg.type === 'INCIDENT_CREATED') this.openIncidents++;
+        if (msg.type === 'INCIDENT_CLOSED') this.openIncidents--;
+      });
+    }).catch((err) => {
+      this.logger.error('Failed to connect to RabbitMQ', { error: err });
+    });
+  }
+
+  async getMetrics(): Promise<Metrics> {
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const runsResult: any = await this.runDb.$queryRaw`SELECT COUNT(*)::int as count FROM "Run" WHERE "startTime" >= ${startOfDay}`;
+    const onTimeResult: any = await this.runDb.$queryRaw`SELECT COUNT(*)::int as count FROM "Run" WHERE "startTime" >= ${startOfDay} AND "actualStartTime" <= "scheduledStartTime"`;
+    const expDocsResult: any = await this.documentDb.$queryRaw`SELECT COUNT(*)::int as count FROM "Document" WHERE (metadata->>'expiryDate')::timestamptz < NOW() + interval '30 day' AND status != 'EXPIRED'`;
+
+    const totalRuns = runsResult[0]?.count || 0;
+    const onTime = onTimeResult[0]?.count || 0;
+    const expiringDocuments = expDocsResult[0]?.count || 0;
+
+    const onTimePercentage = totalRuns ? Math.round((onTime / totalRuns) * 100) : 0;
+
+    return {
+      totalRunsToday: totalRuns,
+      onTimePercentage,
+      openIncidents: this.openIncidents,
+      expiringDocuments
+    };
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,58 @@ importers:
         specifier: ^6.6.2
         version: 6.6.2(encoding@0.1.13)
 
+  packages/admin-service:
+    dependencies:
+      express:
+        specifier: ^4.18.2
+        version: 4.21.2
+      shared:
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.21
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.11.24
+        version: 20.17.30
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.0.1
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.0.1
+        version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@8.57.1)
+      eslint-plugin-prettier:
+        specifier: ^5.1.3
+        version: 5.2.6(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.5.3)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.17.30)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3))
+      nodemon:
+        specifier: ^3.0.3
+        version: 3.1.9
+      prettier:
+        specifier: ^3.2.5
+        version: 3.5.3
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.3.1(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.30)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3)))(typescript@5.8.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.17.30)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+
   packages/api-gateway:
     dependencies:
       express:
@@ -142,6 +194,110 @@ importers:
       winston:
         specifier: ^3.11.0
         version: 3.17.0
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.21
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.11.24
+        version: 20.17.30
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.0.1
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.0.1
+        version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@8.57.1)
+      eslint-plugin-prettier:
+        specifier: ^5.1.3
+        version: 5.2.6(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.5.3)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.17.30)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3))
+      nodemon:
+        specifier: ^3.0.3
+        version: 3.1.9
+      prettier:
+        specifier: ^3.2.5
+        version: 3.5.3
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.3.1(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.30)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3)))(typescript@5.8.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.17.30)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+
+  packages/incident-service:
+    dependencies:
+      express:
+        specifier: ^4.18.2
+        version: 4.21.2
+      shared:
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.21
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.11.24
+        version: 20.17.30
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.0.1
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.0.1
+        version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@8.57.1)
+      eslint-plugin-prettier:
+        specifier: ^5.1.3
+        version: 5.2.6(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.5.3)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.17.30)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3))
+      nodemon:
+        specifier: ^3.0.3
+        version: 3.1.9
+      prettier:
+        specifier: ^3.2.5
+        version: 3.5.3
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.3.1(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.30)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3)))(typescript@5.8.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.17.30)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+
+  packages/invoicing-service:
+    dependencies:
+      express:
+        specifier: ^4.18.2
+        version: 4.21.2
+      shared:
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       '@types/express':
         specifier: ^4.17.21


### PR DESCRIPTION
## Summary
- query run and document data for metrics
- expose tenant configuration endpoints
- wire new services into admin service

## Testing
- `pnpm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6841eb31471c83339bad2150c6099067