### PR TITLE
Add driver availability management

### DIFF
--- a/packages/driver-service/README.md
+++ b/packages/driver-service/README.md
@@ -17,3 +17,14 @@ This service manages driver data and publishes driver events.
    ```bash
    pnpm dev
    ```
+
+## API Usage
+
+- `GET /api/drivers/:id/availability` - Retrieve a driver's availability slots.
+- `PUT /api/drivers/:id/availability` - Replace a driver's availability slots. Example body:
+  ```json
+  [
+    { "startTime": "2024-05-01T08:00:00Z", "endTime": "2024-05-01T12:00:00Z" },
+    { "startTime": "2024-05-02T13:00:00Z", "endTime": "2024-05-02T17:00:00Z" }
+  ]
+  ```

--- a/packages/driver-service/prisma/schema.prisma
+++ b/packages/driver-service/prisma/schema.prisma
@@ -52,6 +52,7 @@ model Driver {
   updatedAt         DateTime @updatedAt
 
   runs Run[] @relation("DriverRuns")
+  availabilities DriverAvailability[]
 }
 
 model Run {
@@ -73,4 +74,15 @@ model Run {
   updatedAt          DateTime  @updatedAt
 
   driver Driver? @relation("DriverRuns", fields: [driverId], references: [id])
+}
+
+model DriverAvailability {
+  id        String   @id @default(uuid())
+  driverId  String
+  startTime DateTime
+  endTime   DateTime
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  driver Driver @relation(fields: [driverId], references: [id])
 }

--- a/packages/driver-service/src/__tests__/services/driver.service.test.ts
+++ b/packages/driver-service/src/__tests__/services/driver.service.test.ts
@@ -12,10 +12,21 @@ const mockPrismaDriver = {
   findMany: jest.fn(),
   delete: jest.fn()
 };
+const mockPrismaRun = {
+  findUnique: jest.fn()
+};
+const mockPrismaAvailability = {
+  findMany: jest.fn(),
+  findFirst: jest.fn(),
+  createMany: jest.fn(),
+  deleteMany: jest.fn()
+};
 
 jest.mock('@prisma/client', () => ({
   PrismaClient: jest.fn().mockImplementation(() => ({
-    driver: mockPrismaDriver
+    driver: mockPrismaDriver,
+    run: mockPrismaRun,
+    driverAvailability: mockPrismaAvailability
   }))
 }));
 
@@ -26,9 +37,13 @@ describe('DriverService', () => {
   let mockDriver: Driver;
 
   beforeEach(() => {
+    jest.resetAllMocks();
     mockRabbitMQ = new RabbitMQService('amqp://localhost') as jest.Mocked<RabbitMQService>;
-    mockPrisma = new PrismaClient() as jest.Mocked<PrismaClient>;
-    Object.assign((mockPrisma as any).driver, mockPrismaDriver);
+    mockPrisma = {
+      driver: mockPrismaDriver,
+      run: mockPrismaRun,
+      driverAvailability: mockPrismaAvailability
+    } as unknown as jest.Mocked<PrismaClient>;
 
     mockDriver = {
       id: 'driver-1',
@@ -179,10 +194,15 @@ describe('DriverService', () => {
   describe('assignDriverToRun', () => {
     it('should assign driver to run', async () => {
       const updatedDriver = { ...mockDriver, currentRunId: 'run-1', status: DriverStatus.ASSIGNED };
+      const run = { id: 'run-1', startTime: new Date(), endTime: new Date(Date.now() + 3600) };
+      mockPrismaRun.findUnique.mockResolvedValue(run);
+      mockPrismaAvailability.findFirst.mockResolvedValue({ id: 'a1' });
       mockPrismaDriver.update.mockResolvedValue(updatedDriver);
 
       const result = await driverService.assignDriverToRun(mockDriver.id, 'run-1');
 
+      expect(mockPrismaRun.findUnique).toHaveBeenCalledWith({ where: { id: 'run-1' } });
+      expect(mockPrismaAvailability.findFirst).toHaveBeenCalled();
       expect(mockPrismaDriver.update).toHaveBeenCalledWith({
         where: { id: mockDriver.id },
         data: {
@@ -228,6 +248,33 @@ describe('DriverService', () => {
       });
 
       expect(result).toEqual(updatedDriver);
+    });
+  });
+
+  describe('getDriverAvailability', () => {
+    it('should return availability for driver', async () => {
+      mockPrismaAvailability.findMany.mockResolvedValue([]);
+      const result = await driverService.getDriverAvailability('driver-1');
+      expect(mockPrismaAvailability.findMany).toHaveBeenCalledWith({
+        where: { driverId: 'driver-1' },
+        orderBy: { startTime: 'asc' }
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('updateDriverAvailability', () => {
+    it('should replace availability for driver', async () => {
+      mockPrismaAvailability.deleteMany.mockResolvedValue({ count: 1 } as any);
+      mockPrismaAvailability.createMany.mockResolvedValue({ count: 2 } as any);
+      mockPrismaAvailability.findMany.mockResolvedValue([{ id: 'a1' } as any]);
+
+      const slots = [{ startTime: new Date(), endTime: new Date() }];
+      const result = await driverService.updateDriverAvailability('driver-1', slots);
+
+      expect(mockPrismaAvailability.deleteMany).toHaveBeenCalledWith({ where: { driverId: 'driver-1' } });
+      expect(mockPrismaAvailability.createMany).toHaveBeenCalled();
+      expect(result).toEqual([{ id: 'a1' }]);
     });
   });
 

--- a/packages/driver-service/src/api/controllers/driver.controller.ts
+++ b/packages/driver-service/src/api/controllers/driver.controller.ts
@@ -99,6 +99,29 @@ export class DriverController {
     }
   }
 
+  async getDriverAvailability(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const availability = await this.driverService.getDriverAvailability(id);
+      res.status(200).json(availability);
+    } catch (error) {
+      console.error('Failed to get driver availability:', error);
+      res.status(500).json({ error: 'Failed to get driver availability' });
+    }
+  }
+
+  async updateDriverAvailability(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const slots = req.body as { startTime: Date; endTime: Date }[];
+      const availability = await this.driverService.updateDriverAvailability(id, slots);
+      res.status(200).json(availability);
+    } catch (error) {
+      console.error('Failed to update driver availability:', error);
+      res.status(500).json({ error: 'Failed to update driver availability' });
+    }
+  }
+
   async getAvailableDrivers(req: Request, res: Response): Promise<void> {
     try {
       const drivers = await this.driverService.getAvailableDrivers();

--- a/packages/driver-service/src/api/routes/driver.routes.ts
+++ b/packages/driver-service/src/api/routes/driver.routes.ts
@@ -58,10 +58,22 @@ export function createDriverRoutes(controller: DriverController): Router {
   );
 
   // Unassign driver from run (admin and coordinator)
-  router.post('/drivers/:driverId/unassign', 
+  router.post('/drivers/:driverId/unassign',
     authenticate(),
     requireRole(['ADMIN', 'COORDINATOR']),
     controller.unassignDriverFromRun.bind(controller)
+  );
+
+  router.get('/drivers/:id/availability',
+    authenticate(),
+    requireRole(['ADMIN', 'COORDINATOR', 'DRIVER']),
+    controller.getDriverAvailability.bind(controller)
+  );
+
+  router.put('/drivers/:id/availability',
+    authenticate(),
+    requireRole(['ADMIN', 'DRIVER']),
+    controller.updateDriverAvailability.bind(controller)
   );
 
   // Get available drivers (admin and coordinator)

--- a/packages/shared/src/types/driver.ts
+++ b/packages/shared/src/types/driver.ts
@@ -28,4 +28,13 @@ export interface Driver {
   currentRunId: string | null;
   createdAt: Date;
   updatedAt: Date;
-} 
+}
+
+export interface DriverAvailability {
+  id: string;
+  driverId: string;
+  startTime: Date;
+  endTime: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}


### PR DESCRIPTION
## Summary
- add `DriverAvailability` model in Prisma schema
- expose driver availability endpoints
- check availability when assigning runs
- update service implementations and tests
- document API usage

## Testing
- `pnpm --filter driver-service test`

------
https://chatgpt.com/codex/tasks/task_e_6841eb5a849c83338cabd4555800e32e