### PR TITLE
Add latest location endpoint

### DIFF
--- a/packages/api-gateway/README.md
+++ b/packages/api-gateway/README.md
@@ -13,6 +13,7 @@ traffic to the underlying services and enforces authentication using the shared
 - `DRIVER_SERVICE_URL` - URL of the driver service (default: `http://localhost:3004`)
 - `VEHICLE_SERVICE_URL` - URL of the vehicle service (default: `http://localhost:3005`)
 - `DOCUMENT_SERVICE_URL` - URL of the document service (default: `http://localhost:3006`)
+- `TRACKING_SERVICE_URL` - URL of the tracking service (default: `http://localhost:3003`)
 
 ## Development
 

--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -21,6 +21,7 @@ app.use('/api/students', createProxyMiddleware({ target: serviceConfig.studentSe
 app.use('/api/drivers', createProxyMiddleware({ target: serviceConfig.driverService, changeOrigin: true }));
 app.use('/api/vehicles', createProxyMiddleware({ target: serviceConfig.vehicleService, changeOrigin: true }));
 app.use('/api/documents', createProxyMiddleware({ target: serviceConfig.documentService, changeOrigin: true }));
+app.use('/api/locations', createProxyMiddleware({ target: serviceConfig.trackingService, changeOrigin: true }));
 app.use('/api/incidents', createProxyMiddleware({ target: serviceConfig.incidentService, changeOrigin: true }));
 app.use('/api/invoices', createProxyMiddleware({ target: serviceConfig.invoicingService, changeOrigin: true }));
 app.use('/api/admin', createProxyMiddleware({ target: serviceConfig.adminService, changeOrigin: true }));

--- a/packages/api-gateway/src/config.ts
+++ b/packages/api-gateway/src/config.ts
@@ -5,6 +5,7 @@ export const serviceConfig = {
   driverService: process.env.DRIVER_SERVICE_URL || 'http://localhost:3004',
   vehicleService: process.env.VEHICLE_SERVICE_URL || 'http://localhost:3005',
   documentService: process.env.DOCUMENT_SERVICE_URL || 'http://localhost:3006',
+  trackingService: process.env.TRACKING_SERVICE_URL || 'http://localhost:3003',
   incidentService: process.env.INCIDENT_SERVICE_URL || 'http://localhost:3010',
   invoicingService: process.env.INVOICING_SERVICE_URL || 'http://localhost:3011',
   adminService: process.env.ADMIN_SERVICE_URL || 'http://localhost:3012'

--- a/packages/tracking-service/README.md
+++ b/packages/tracking-service/README.md
@@ -29,6 +29,7 @@ The service is built with the following components:
 - `POST /api/tracking/:runId/location` - Update location for a run
 - `POST /api/tracking/:runId/stop` - Stop tracking a run
 - `GET /api/tracking/:runId/status` - Get tracking status for a run
+- `GET /api/locations/:routeId/latest` - Get the most recent location for a run
 
 ### WebSocket Events
 

--- a/packages/tracking-service/src/api/controllers/tracking.controller.ts
+++ b/packages/tracking-service/src/api/controllers/tracking.controller.ts
@@ -50,4 +50,23 @@ export class TrackingController {
       res.status(500).json({ error: 'Failed to get tracking status' });
     }
   }
-} 
+
+  async getLatestLocation(req: Request, res: Response): Promise<void> {
+    try {
+      const { routeId } = req.params;
+      const location = this.trackingService.getLatestLocation(routeId);
+      if (!location) {
+        res.status(404).json({ error: 'Location not found' });
+        return;
+      }
+      res.status(200).json({
+        lat: location.latitude,
+        lng: location.longitude,
+        timestamp: location.timestamp,
+      });
+    } catch (error) {
+      console.error('Failed to get latest location:', error);
+      res.status(500).json({ error: 'Failed to get latest location' });
+    }
+  }
+}

--- a/packages/tracking-service/src/api/routes/tracking.routes.ts
+++ b/packages/tracking-service/src/api/routes/tracking.routes.ts
@@ -22,5 +22,8 @@ export function createTrackingRoutes(controller: TrackingController): Router {
   // Get tracking status for a run
   router.get('/tracking/:runId/status', authMiddleware, controller.getTrackingStatus.bind(controller));
 
+  // Get latest location for a run
+  router.get('/locations/:routeId/latest', authMiddleware, controller.getLatestLocation.bind(controller));
+
   return router;
 } 

--- a/packages/tracking-service/src/infra/services/tracking.service.ts
+++ b/packages/tracking-service/src/infra/services/tracking.service.ts
@@ -107,6 +107,10 @@ export class TrackingService {
     });
   }
 
+  getLatestLocation(runId: string): Location | undefined {
+    return this.activeRuns.get(runId)?.lastLocation;
+  }
+
   private async checkGeofences(location: Location): Promise<Geofence[]> {
     const point: GeolibCoordinates = {
       latitude: location.latitude,


### PR DESCRIPTION
## Summary
- expose `/api/locations/:routeId/latest` from tracking-service
- fetch latest location from `TrackingService`
- proxy `/api/locations` through the API gateway
- document new configuration and endpoint

## Testing
- `pnpm --filter tracking-service test` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*

------
https://chatgpt.com/codex/tasks/task_e_6841eb5e07548333b71dee43c2d8351c