### PR TITLE
Add telemetry support to vehicle-service

### DIFF
--- a/packages/shared/src/types/vehicle.ts
+++ b/packages/shared/src/types/vehicle.ts
@@ -19,7 +19,8 @@ export enum VehicleEventType {
   VEHICLE_STATUS_CHANGED = 'VEHICLE_STATUS_CHANGED',
   VEHICLE_ASSIGNED = 'VEHICLE_ASSIGNED',
   VEHICLE_UNASSIGNED = 'VEHICLE_UNASSIGNED',
-  MAINTENANCE_RECORD_ADDED = 'MAINTENANCE_RECORD_ADDED'
+  MAINTENANCE_RECORD_ADDED = 'MAINTENANCE_RECORD_ADDED',
+  TELEMETRY_RECORDED = 'TELEMETRY_RECORDED'
 }
 
 export enum AlertType {
@@ -68,10 +69,21 @@ export interface MaintenanceRecord {
   updatedAt: Date;
 }
 
+export interface TelemetryRecord {
+  id: string;
+  vehicleId: string;
+  speed?: number;
+  fuelLevel?: number;
+  location?: { latitude: number; longitude: number } | null;
+  recordedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 export interface VehicleEvent {
   type: VehicleEventType;
   vehicleId: string;
-  data: Partial<Vehicle> | MaintenanceRecord;
+  data: Partial<Vehicle> | MaintenanceRecord | TelemetryRecord;
   timestamp: Date;
 }
 

--- a/packages/vehicle-service/README.md
+++ b/packages/vehicle-service/README.md
@@ -63,6 +63,16 @@ Optional query parameters:
 DELETE /vehicles/:id
 ```
 
+### Add Telemetry
+```http
+POST /vehicles/:id/telemetry
+```
+
+### Get Latest Telemetry
+```http
+GET /vehicles/:id/telemetry/latest
+```
+
 ## Performance Considerations
 
 The service implements several performance optimizations:

--- a/packages/vehicle-service/prisma/schema.prisma
+++ b/packages/vehicle-service/prisma/schema.prisma
@@ -74,7 +74,7 @@
    @@map("maintenance_records")
  }
 
- model Alert {
+model Alert {
    id        String       @id @default(uuid())
    vehicleId String
    vehicle   Vehicle      @relation(fields: [vehicleId], references: [id])
@@ -83,7 +83,21 @@
    message   String
    timestamp DateTime
    status    AlertStatus  @default(ACTIVE)
-   details   Json
+  details   Json
 
-   @@map("vehicle_alerts")
- }
+  @@map("vehicle_alerts")
+}
+
+model TelemetryRecord {
+  id        String   @id @default(uuid())
+  vehicleId String
+  vehicle   Vehicle  @relation(fields: [vehicleId], references: [id])
+  speed     Float?
+  fuelLevel Float?
+  location  Json?
+  recordedAt DateTime @default(now())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("telemetry_records")
+}

--- a/packages/vehicle-service/src/api/controllers/vehicle.controller.ts
+++ b/packages/vehicle-service/src/api/controllers/vehicle.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import { VehicleService } from '../../services/vehicle.service';
-import { CreateVehicleDto, UpdateVehicleDto } from '../dto/vehicle.dto';
+import { CreateVehicleDto, UpdateVehicleDto, TelemetryRecordDto } from '../dto/vehicle.dto';
 import { VehicleStatus } from '@shared/types/vehicle';
 
 export class VehicleController {
@@ -116,4 +116,29 @@ export class VehicleController {
       res.status(500).json({ message: 'Error getting maintenance history', error });
     }
   }
-} 
+
+  async addTelemetryRecord(req: Request, res: Response): Promise<void> {
+    try {
+      const record = await this.vehicleService.addTelemetryRecord(
+        req.params.id,
+        req.body as TelemetryRecordDto
+      );
+      res.status(201).json(record);
+    } catch (error) {
+      res.status(500).json({ message: 'Error adding telemetry record', error });
+    }
+  }
+
+  async getLatestTelemetry(req: Request, res: Response): Promise<void> {
+    try {
+      const record = await this.vehicleService.getLatestTelemetry(req.params.id);
+      if (!record) {
+        res.status(404).json({ message: 'Telemetry not found' });
+        return;
+      }
+      res.json(record);
+    } catch (error) {
+      res.status(500).json({ message: 'Error getting latest telemetry', error });
+    }
+  }
+}

--- a/packages/vehicle-service/src/api/dto/vehicle.dto.ts
+++ b/packages/vehicle-service/src/api/dto/vehicle.dto.ts
@@ -25,4 +25,11 @@ export interface MaintenanceRecordDto {
   description: string;
   cost: number;
   date?: Date;
-} 
+}
+
+export interface TelemetryRecordDto {
+  speed?: number;
+  fuelLevel?: number;
+  location?: { latitude: number; longitude: number } | null;
+  recordedAt?: Date;
+}

--- a/packages/vehicle-service/src/api/routes/vehicle.routes.ts
+++ b/packages/vehicle-service/src/api/routes/vehicle.routes.ts
@@ -27,5 +27,8 @@ export function createVehicleRoutes(controller: VehicleController): Router {
   // Vehicle alerts route
   router.get('/:id/maintenance/history', controller.getMaintenanceHistory.bind(controller));
 
+  router.post('/:id/telemetry', controller.addTelemetryRecord.bind(controller));
+  router.get('/:id/telemetry/latest', controller.getLatestTelemetry.bind(controller));
+
   return router;
 } 

--- a/packages/vehicle-service/src/index.ts
+++ b/packages/vehicle-service/src/index.ts
@@ -12,7 +12,7 @@ const prisma = new PrismaClient();
 const rabbitMQService = new RabbitMQService();
 
 // Create services and controllers
-const vehicleService = new VehicleService();
+const vehicleService = new VehicleService(rabbitMQService);
 const vehicleController = new VehicleController(vehicleService);
 
 // Middleware

--- a/packages/vehicle-service/src/types/vehicle.ts
+++ b/packages/vehicle-service/src/types/vehicle.ts
@@ -66,4 +66,15 @@ export interface MaintenanceRecord {
   date: Date;
   createdAt: Date;
   updatedAt: Date;
-} 
+}
+
+export interface TelemetryRecord {
+  id: string;
+  vehicleId: string;
+  speed?: number;
+  fuelLevel?: number;
+  location?: { latitude: number; longitude: number } | null;
+  recordedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/packages/vehicle-service/src/types/vehicle.types.ts
+++ b/packages/vehicle-service/src/types/vehicle.types.ts
@@ -58,6 +58,13 @@ export interface VehicleEvent {
       description: string;
       date: string;
     };
+    telemetryRecord?: {
+      id: string;
+      speed?: number;
+      fuelLevel?: number;
+      location?: { latitude: number; longitude: number } | null;
+      recordedAt: string;
+    };
     runId?: string;
     previousStatus?: VehicleStatus;
     newStatus?: VehicleStatus;


### PR DESCRIPTION
## Summary
- support telemetry storage with Prisma model
- expose POST `/vehicles/:id/telemetry` and GET `/vehicles/:id/telemetry/latest`
- broadcast telemetry events on RabbitMQ when available
- document new endpoints
- extend unit tests for telemetry

## Testing
- `pnpm --filter vehicle-service test` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm --filter vehicle-service lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6841eb5f7d648333959e84798dab7230