### PR TITLE
Add logging and resilient proxy to API Gateway

### DIFF
--- a/packages/api-gateway/README.md
+++ b/packages/api-gateway/README.md
@@ -13,6 +13,9 @@ traffic to the underlying services and enforces authentication using the shared
 - `DRIVER_SERVICE_URL` - URL of the driver service (default: `http://localhost:3004`)
 - `VEHICLE_SERVICE_URL` - URL of the vehicle service (default: `http://localhost:3005`)
 - `DOCUMENT_SERVICE_URL` - URL of the document service (default: `http://localhost:3006`)
+- `LOG_LEVEL` - Log verbosity (default: `info`)
+- `PROXY_RETRY_ATTEMPTS` - Number of retry attempts for proxied requests (default: `3`)
+- `PROXY_RETRY_DELAY_MS` - Delay between retries in milliseconds (default: `100`)
 
 ## Development
 

--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -3,6 +3,53 @@ import { createProxyMiddleware } from 'http-proxy-middleware';
 import { authenticate } from '@send/shared';
 import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { serviceConfig } from './config';
+import { LoggerService } from '@shared/logging/logger.service';
+import { CircuitBreakerService } from '@shared/circuit-breaker';
+
+const logger = new LoggerService({
+  serviceName: 'api-gateway',
+  logLevel: process.env.LOG_LEVEL || 'info'
+});
+
+const retryAttempts = parseInt(process.env.PROXY_RETRY_ATTEMPTS || '3', 10);
+const retryDelay = parseInt(process.env.PROXY_RETRY_DELAY_MS || '100', 10);
+
+function createResilientProxy(target: string, serviceName: string) {
+  const breaker = new CircuitBreakerService(serviceName);
+  const proxy = createProxyMiddleware({ target, changeOrigin: true });
+
+  return async (
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction
+  ) => {
+    for (let attempt = 0; attempt < retryAttempts; attempt++) {
+      try {
+        await breaker.execute(
+          () =>
+            new Promise<void>((resolve, reject) => {
+              proxy(req, res, err => {
+                if (err) reject(err);
+                else resolve();
+              });
+            })
+        );
+        return;
+      } catch (error) {
+        logger.warn(`Proxy attempt ${attempt + 1} failed for ${serviceName}`, {
+          error
+        });
+        if (attempt < retryAttempts - 1) {
+          await new Promise(resolve => setTimeout(resolve, retryDelay));
+        } else {
+          logger.error(`Proxy failed for ${serviceName}`, { error });
+          return res.status(502).json({ error: 'Bad gateway' });
+        }
+      }
+    }
+    next();
+  };
+}
 
 const app = express();
 
@@ -10,19 +57,63 @@ app.use(express.json());
 app.use(securityHeaders);
 app.use(rateLimit('api-gateway'));
 
+// Request/response logging
+app.use((req, res, next) => {
+  res.on('finish', () => {
+    logger.info('Request handled', {
+      method: req.method,
+      path: req.path,
+      status: res.statusCode,
+      userId: (req as any).user?.id || null
+    });
+  });
+  next();
+});
+
 // Apply authentication to all API routes
 app.use('/api', authenticate());
 
 // Proxy rules
-app.use('/api/auth', createProxyMiddleware({ target: serviceConfig.userService, changeOrigin: true }));
-app.use('/api/users', createProxyMiddleware({ target: serviceConfig.userService, changeOrigin: true }));
-app.use('/api/runs', createProxyMiddleware({ target: serviceConfig.runService, changeOrigin: true }));
-app.use('/api/students', createProxyMiddleware({ target: serviceConfig.studentService, changeOrigin: true }));
-app.use('/api/drivers', createProxyMiddleware({ target: serviceConfig.driverService, changeOrigin: true }));
-app.use('/api/vehicles', createProxyMiddleware({ target: serviceConfig.vehicleService, changeOrigin: true }));
-app.use('/api/documents', createProxyMiddleware({ target: serviceConfig.documentService, changeOrigin: true }));
-app.use('/api/incidents', createProxyMiddleware({ target: serviceConfig.incidentService, changeOrigin: true }));
-app.use('/api/invoices', createProxyMiddleware({ target: serviceConfig.invoicingService, changeOrigin: true }));
-app.use('/api/admin', createProxyMiddleware({ target: serviceConfig.adminService, changeOrigin: true }));
+app.use('/api/auth', createResilientProxy(serviceConfig.userService, 'user-service'));
+app.use('/api/users', createResilientProxy(serviceConfig.userService, 'user-service'));
+app.use('/api/runs', createResilientProxy(serviceConfig.runService, 'run-service'));
+app.use('/api/students', createResilientProxy(serviceConfig.studentService, 'student-service'));
+app.use('/api/drivers', createResilientProxy(serviceConfig.driverService, 'driver-service'));
+app.use('/api/vehicles', createResilientProxy(serviceConfig.vehicleService, 'vehicle-service'));
+app.use('/api/documents', createResilientProxy(serviceConfig.documentService, 'document-service'));
+app.use('/api/incidents', createResilientProxy(serviceConfig.incidentService, 'incident-service'));
+app.use('/api/invoices', createResilientProxy(serviceConfig.invoicingService, 'invoicing-service'));
+app.use('/api/admin', createResilientProxy(serviceConfig.adminService, 'admin-service'));
+
+// Aggregate health check
+app.get('/health', async (_req, res) => {
+  const services = {
+    userService: serviceConfig.userService,
+    runService: serviceConfig.runService,
+    studentService: serviceConfig.studentService,
+    driverService: serviceConfig.driverService,
+    vehicleService: serviceConfig.vehicleService,
+    documentService: serviceConfig.documentService,
+    incidentService: serviceConfig.incidentService,
+    invoicingService: serviceConfig.invoicingService,
+    adminService: serviceConfig.adminService
+  } as const;
+
+  const results: Record<string, any> = {};
+  await Promise.all(
+    Object.entries(services).map(async ([name, url]) => {
+      try {
+        const resp = await fetch(`${url}/health`, {
+          signal: AbortSignal.timeout(3000)
+        });
+        results[name] = await resp.json();
+      } catch (err) {
+        results[name] = { status: 'DOWN' };
+      }
+    })
+  );
+
+  res.status(200).json(results);
+});
 
 export default app;


### PR DESCRIPTION
## Summary
- log requests and responses in the API Gateway
- use a circuit breaker with retry handling around proxy routes
- query downstream services in the new `/health` route
- document LOG_LEVEL and retry variables for the gateway

## Testing
- `pnpm test` *(fails: log shows Prisma generation started but environment lacks dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841eeaa5c6c83338f9b9765eccf4b84