### PR TITLE
Fix run rating mapping

### DIFF
--- a/packages/run-service/src/data/models/run.model.ts
+++ b/packages/run-service/src/data/models/run.model.ts
@@ -99,6 +99,7 @@ export class RunModel {
       endDate: prismaRun.endDate ?? undefined,
       lastOccurrence: prismaRun.lastOccurrence ?? undefined,
       nextOccurrence: prismaRun.nextOccurrence ?? undefined,
+      rating: prismaRun.rating ?? undefined,
       pickupLocation: JSON.parse(prismaRun.pickupLocation as string),
       dropoffLocation: JSON.parse(prismaRun.dropoffLocation as string),
       studentIds: JSON.parse(prismaRun.studentIds as string),


### PR DESCRIPTION
## Summary
- normalize null run ratings to `undefined` in the run model

## Testing
- `npm test -w packages/run-service` *(fails: RabbitMQ connection error)*
- `npm run lint -w packages/run-service` *(fails: eslint config error)*
- `npm run build -w packages/run-service` *(fails: missing compiled shared types)*

------
https://chatgpt.com/codex/tasks/task_e_68420522eff883338380cd3253e5b6e3