### PR TITLE
Add README for shared types package

### DIFF
--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,17 @@
+# Types Package
+
+Common TypeScript definitions shared across services. Currently this folder provides:
+
+- `DriverStatus` – enumerates driver lifecycle states.
+- `Driver` – interface representing the driver record returned by services.
+
+Other packages can import these definitions using a path alias or relative import. For example:
+
+```ts
+import { Driver, DriverStatus } from '@send/types/driver';
+// or
+import { Driver, DriverStatus } from '../types/driver';
+```
+
+Configure your `tsconfig.json` paths if you prefer the `@send/types` alias.
+


### PR DESCRIPTION
## Summary
- add `packages/types/README.md` with info on provided TypeScript definitions and usage

## Testing
- `npm test` *(fails: Prisma schema validation)*

------
https://chatgpt.com/codex/tasks/task_e_684208af7300833385361c1552a80271