### PR TITLE
Fix logging and tracing service imports

### DIFF
--- a/packages/user-service/src/main.ts
+++ b/packages/user-service/src/main.ts
@@ -1,7 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { LoggingService } from '@shared/shared';
-import { TracingService } from '@shared/shared';
+import { LoggingService } from 'shared/src/services/logging.service';
+import { TracingService } from 'shared/src/services/tracing.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);


### PR DESCRIPTION
## Summary
- fix imports for LoggingService and TracingService in user-service main.ts

## Testing
- `npx tsc --noEmit packages/user-service/src/main.ts` *(fails: Cannot find type definition file for 'hapi__shot')*
- `npm test` *(fails during Prisma schema validation)*

------
https://chatgpt.com/codex/tasks/task_e_684208d8ec908333845375d5008354a3