### PR TITLE
Add minimal tests for admin and invoicing services

### DIFF
--- a/packages/admin-service/src/__tests__/controllers/admin.controller.test.ts
+++ b/packages/admin-service/src/__tests__/controllers/admin.controller.test.ts
@@ -1,0 +1,67 @@
+import request from 'supertest';
+import express from 'express';
+import { AdminController } from '../../api/controllers/admin.controller';
+import { MetricsService } from '../../services/metrics.service';
+import { ConfigService } from '../../services/config.service';
+
+describe('AdminController', () => {
+  let app: express.Application;
+  let metricsService: jest.Mocked<MetricsService>;
+  let configService: jest.Mocked<ConfigService>;
+  let controller: AdminController;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+
+    metricsService = { getMetrics: jest.fn() } as any;
+    configService = {
+      getConfig: jest.fn(),
+      updateConfig: jest.fn()
+    } as any;
+
+    controller = new AdminController(metricsService, configService);
+
+    app.get('/admin/metrics', (req, res) => controller.metrics(req, res));
+    app.get('/admin/config', (req, res) => controller.getConfig(req, res));
+    app.put('/admin/config', (req, res) => controller.updateConfig(req, res));
+  });
+
+  it('returns metrics', async () => {
+    metricsService.getMetrics.mockResolvedValue({
+      totalRunsToday: 5,
+      onTimePercentage: 100,
+      openIncidents: 0,
+      expiringDocuments: 1
+    } as any);
+
+    const res = await request(app).get('/admin/metrics');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      totalRunsToday: 5,
+      onTimePercentage: 100,
+      openIncidents: 0,
+      expiringDocuments: 1
+    });
+  });
+
+  it('gets config', async () => {
+    configService.getConfig.mockResolvedValue({ key: 'value' });
+
+    const res = await request(app).get('/admin/config');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ key: 'value' });
+  });
+
+  it('updates config', async () => {
+    configService.updateConfig.mockResolvedValue({ foo: 'bar' });
+
+    const res = await request(app).put('/admin/config').send({ foo: 'bar' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ foo: 'bar' });
+    expect(configService.updateConfig).toHaveBeenCalledWith({ foo: 'bar' });
+  });
+});

--- a/packages/admin-service/src/__tests__/services/config.service.test.ts
+++ b/packages/admin-service/src/__tests__/services/config.service.test.ts
@@ -1,0 +1,15 @@
+import { ConfigService } from '../../services/config.service';
+
+describe('ConfigService', () => {
+  it('retrieves and updates configuration', async () => {
+    const service = new ConfigService();
+
+    expect(await service.getConfig()).toEqual({});
+
+    await service.updateConfig({ a: 1 });
+    expect(await service.getConfig()).toEqual({ a: 1 });
+
+    await service.updateConfig({ b: 2 });
+    expect(await service.getConfig()).toEqual({ a: 1, b: 2 });
+  });
+});

--- a/packages/invoicing-service/jest.config.js
+++ b/packages/invoicing-service/jest.config.js
@@ -9,6 +9,12 @@ module.exports = {
   moduleNameMapper: {
     '^@send/shared$': '<rootDir>/../shared/src',
     '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@shared/(.*)$': '<rootDir>/../shared/src/$1'
+    '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
+    '^@prisma/client$': '<rootDir>/../../test/prisma-client.ts'
+  },
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.test.json'
+    }
   }
 };

--- a/packages/invoicing-service/src/__tests__/controllers/invoice.controller.test.ts
+++ b/packages/invoicing-service/src/__tests__/controllers/invoice.controller.test.ts
@@ -1,0 +1,48 @@
+import request from 'supertest';
+import express from 'express';
+import { InvoiceController } from '../../api/controllers/invoice.controller';
+import { InvoiceService } from '../../services/invoice.service';
+
+describe('InvoiceController', () => {
+  let app: express.Application;
+  let service: jest.Mocked<InvoiceService>;
+  let controller: InvoiceController;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+
+    service = {
+      createInvoice: jest.fn(),
+      listInvoices: jest.fn(),
+      getInvoice: jest.fn(),
+      updateInvoiceStatus: jest.fn(),
+      sendInvoiceToSage: jest.fn()
+    } as any;
+
+    controller = new InvoiceController(service);
+
+    app.post('/invoices', (req, res) => controller.create(req, res));
+    app.get('/invoices/:id', (req, res) => controller.getById(req, res));
+  });
+
+  it('creates an invoice', async () => {
+    const invoice = { id: '1' } as any;
+    service.createInvoice.mockResolvedValue(invoice);
+
+    const res = await request(app).post('/invoices').send({});
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(invoice);
+    expect(service.createInvoice).toHaveBeenCalled();
+  });
+
+  it('returns 404 when invoice missing', async () => {
+    service.getInvoice.mockResolvedValue(null);
+
+    const res = await request(app).get('/invoices/1');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Invoice not found' });
+  });
+});

--- a/packages/invoicing-service/src/__tests__/services/invoice.service.test.ts
+++ b/packages/invoicing-service/src/__tests__/services/invoice.service.test.ts
@@ -1,0 +1,48 @@
+import { InvoiceService } from '../../services/invoice.service';
+import { InvoiceStatus } from '@shared/types/invoice';
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(() => ({}))
+}));
+
+describe('InvoiceService', () => {
+  let prisma: any;
+  let service: InvoiceService;
+
+  beforeEach(() => {
+    prisma = {
+      invoice: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn()
+      }
+    };
+
+    service = new InvoiceService(prisma);
+  });
+
+  it('creates an invoice', async () => {
+    const input = { routeId: 'r1', amount: 100, dueAt: new Date() };
+    const invoice = { id: '1', ...input, status: InvoiceStatus.PENDING } as any;
+    prisma.invoice.create.mockResolvedValue(invoice);
+
+    const result = await service.createInvoice(input);
+
+    expect(prisma.invoice.create).toHaveBeenCalled();
+    expect(result).toEqual(invoice);
+  });
+
+  it('updates invoice status', async () => {
+    const invoice = { id: '1', status: InvoiceStatus.PAID } as any;
+    prisma.invoice.update.mockResolvedValue(invoice);
+
+    const result = await service.updateInvoiceStatus('1', InvoiceStatus.PAID);
+
+    expect(prisma.invoice.update).toHaveBeenCalledWith({
+      where: { id: '1' },
+      data: { status: InvoiceStatus.PAID }
+    });
+    expect(result).toEqual(invoice);
+  });
+});

--- a/packages/invoicing-service/tsconfig.json
+++ b/packages/invoicing-service/tsconfig.json
@@ -3,11 +3,11 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "baseUrl": "./src",
+    "baseUrl": ".",
     "paths": {
-      "@shared/*": ["../../shared/src/*"],
-      "@send/shared": ["../../shared/src"],
-      "@send/shared/*": ["../../shared/src/*"]
+      "@shared/*": ["../shared/src/*"],
+      "@send/shared": ["../shared/src"],
+      "@send/shared/*": ["../shared/src/*"]
     },
     "types": ["node", "jest", "express"]
   },

--- a/packages/invoicing-service/tsconfig.test.json
+++ b/packages/invoicing-service/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@shared/*": ["../shared/src/*"],
+      "@send/shared": ["../shared/src"],
+      "@send/shared/*": ["../shared/src/*"],
+      "@prisma/client": ["../../test/prisma-client.ts"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add ConfigService unit test and AdminController tests
- create InvoiceService and InvoiceController tests
- configure Jest and tsconfig for invoicing-service tests

## Testing
- `npx lerna run test --scope admin-service --scope invoicing-service --concurrency 1`

------
https://chatgpt.com/codex/tasks/task_e_684208c54bb48333b478783bffc76978