### PR TITLE
Implement report service and tests

### DIFF
--- a/packages/admin-service/src/__tests__/controllers/admin.controller.test.ts
+++ b/packages/admin-service/src/__tests__/controllers/admin.controller.test.ts
@@ -3,11 +3,13 @@ import express from 'express';
 import { AdminController } from '../../api/controllers/admin.controller';
 import { MetricsService } from '../../services/metrics.service';
 import { ConfigService } from '../../services/config.service';
+import { ReportService } from '../../services/report.service';
 
 describe('AdminController', () => {
   let app: express.Application;
   let metricsService: jest.Mocked<MetricsService>;
   let configService: jest.Mocked<ConfigService>;
+  let reportService: jest.Mocked<ReportService>;
   let controller: AdminController;
 
   beforeEach(() => {
@@ -19,10 +21,12 @@ describe('AdminController', () => {
       getConfig: jest.fn(),
       updateConfig: jest.fn()
     } as any;
+    reportService = { getReports: jest.fn() } as any;
 
-    controller = new AdminController(metricsService, configService);
+    controller = new AdminController(metricsService, configService, reportService);
 
     app.get('/admin/metrics', (req, res) => controller.metrics(req, res));
+    app.get('/admin/reports', (req, res) => controller.reports(req, res));
     app.get('/admin/config', (req, res) => controller.getConfig(req, res));
     app.put('/admin/config', (req, res) => controller.updateConfig(req, res));
   });
@@ -44,6 +48,15 @@ describe('AdminController', () => {
       openIncidents: 0,
       expiringDocuments: 1
     });
+  });
+
+  it('returns reports', async () => {
+    reportService.getReports.mockResolvedValue([{ generatedAt: 'now', metrics: { a: 1 } }] as any);
+
+    const res = await request(app).get('/admin/reports');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ generatedAt: 'now', metrics: { a: 1 } }]);
   });
 
   it('gets config', async () => {

--- a/packages/admin-service/src/__tests__/services/report.service.test.ts
+++ b/packages/admin-service/src/__tests__/services/report.service.test.ts
@@ -1,0 +1,20 @@
+import { ReportService } from '../../services/report.service';
+import { MetricsService } from '../../services/metrics.service';
+
+describe('ReportService', () => {
+  it('generates and retrieves reports', async () => {
+    const metricsService = { getMetrics: jest.fn().mockResolvedValue({ a: 1 }) } as any as jest.Mocked<MetricsService>;
+    const service = new ReportService(metricsService);
+
+    const reports = await service.getReports();
+    expect(reports.length).toBe(1);
+    expect(reports[0]).toHaveProperty('generatedAt');
+    expect(reports[0].metrics).toEqual({ a: 1 });
+
+    metricsService.getMetrics.mockResolvedValue({ a: 2 } as any);
+    await service.generateReport();
+    const updated = await service.getReports();
+    expect(updated.length).toBe(2);
+    expect(updated[1].metrics).toEqual({ a: 2 });
+  });
+});

--- a/packages/admin-service/src/api/controllers/admin.controller.ts
+++ b/packages/admin-service/src/api/controllers/admin.controller.ts
@@ -1,11 +1,13 @@
 import { Request, Response } from 'express';
 import { MetricsService } from '../../services/metrics.service';
 import { ConfigService } from '../../services/config.service';
+import { ReportService } from '../../services/report.service';
 
 export class AdminController {
   constructor(
     private readonly metricsService: MetricsService,
-    private readonly configService: ConfigService
+    private readonly configService: ConfigService,
+    private readonly reportService: ReportService
   ) {}
 
   async metrics(req: Request, res: Response): Promise<void> {
@@ -14,7 +16,8 @@ export class AdminController {
   }
 
   async reports(req: Request, res: Response): Promise<void> {
-    res.json([]);
+    const reports = await this.reportService.getReports();
+    res.json(reports);
   }
 
   async getConfig(req: Request, res: Response): Promise<void> {

--- a/packages/admin-service/src/app.ts
+++ b/packages/admin-service/src/app.ts
@@ -6,10 +6,12 @@ import { AdminController } from './api/controllers/admin.controller';
 import { createAdminRoutes } from './api/routes/admin.routes';
 import { MetricsService } from './services/metrics.service';
 import { ConfigService } from './services/config.service';
+import { ReportService } from './services/report.service';
 
 const metricsService = new MetricsService();
 const configService = new ConfigService();
-const controller = new AdminController(metricsService, configService);
+const reportService = new ReportService(metricsService);
+const controller = new AdminController(metricsService, configService, reportService);
 
 const app = express();
 app.use(express.json());

--- a/packages/admin-service/src/services/report.service.ts
+++ b/packages/admin-service/src/services/report.service.ts
@@ -1,0 +1,26 @@
+import { MetricsService } from './metrics.service';
+
+export interface Report {
+  generatedAt: Date;
+  metrics: Awaited<ReturnType<MetricsService['getMetrics']>>;
+}
+
+export class ReportService {
+  private reports: Report[] = [];
+
+  constructor(private readonly metricsService: MetricsService) {}
+
+  async generateReport(): Promise<Report> {
+    const metrics = await this.metricsService.getMetrics();
+    const report: Report = { generatedAt: new Date(), metrics };
+    this.reports.push(report);
+    return report;
+  }
+
+  async getReports(): Promise<Report[]> {
+    if (this.reports.length === 0) {
+      await this.generateReport();
+    }
+    return this.reports;
+  }
+}


### PR DESCRIPTION
## Summary
- add `ReportService` to handle gathering of metrics-based reports
- inject new service into `AdminController`
- expose reports via `/admin/reports` route
- update app wiring for the new service
- test controller and service functionality

## Testing
- `npx lerna run test --scope=admin-service`

------
https://chatgpt.com/codex/tasks/task_e_68420df0dcec8333897b7c50243e9585