### PR TITLE
Implement tracking status endpoint

### DIFF
--- a/packages/tracking-service/jest.config.js
+++ b/packages/tracking-service/jest.config.js
@@ -10,6 +10,12 @@ module.exports = {
     '^@send/shared$': '<rootDir>/../shared/src',
     '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
     '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
+    '^@prisma/client$': '<rootDir>/../../test/prisma-client.ts'
+  },
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.test.json'
+    }
   },
   coverageDirectory: 'coverage',
   collectCoverageFrom: [

--- a/packages/tracking-service/src/__tests__/controllers/tracking.controller.test.ts
+++ b/packages/tracking-service/src/__tests__/controllers/tracking.controller.test.ts
@@ -1,0 +1,64 @@
+import { Request, Response } from 'express';
+import { TrackingController } from '../../api/controllers/tracking.controller';
+import { TrackingService } from '../../infra/services/tracking.service';
+
+describe('TrackingController - getTrackingStatus', () => {
+  let controller: TrackingController;
+  let service: jest.Mocked<TrackingService>;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    service = {
+      startTracking: jest.fn(),
+      updateLocation: jest.fn(),
+      stopTracking: jest.fn(),
+      getLatestLocation: jest.fn(),
+      addClient: jest.fn(),
+      removeClient: jest.fn(),
+      trackLocation: jest.fn(),
+      getTrackingStatus: jest.fn(),
+    } as unknown as jest.Mocked<TrackingService>;
+
+    controller = new TrackingController(service);
+
+    req = { params: {}, body: {} };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as unknown as Partial<Response>;
+  });
+
+  it('returns status when run is tracked', async () => {
+    req.params = { runId: 'run1' };
+    service.getTrackingStatus.mockReturnValue('IN_PROGRESS' as any);
+
+    await controller.getTrackingStatus(req as Request, res as Response);
+
+    expect(service.getTrackingStatus).toHaveBeenCalledWith('run1');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ status: 'IN_PROGRESS' });
+  });
+
+  it('returns 404 when run not found', async () => {
+    req.params = { runId: 'missing' };
+    service.getTrackingStatus.mockReturnValue(undefined);
+
+    await controller.getTrackingStatus(req as Request, res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Run not found' });
+  });
+
+  it('handles errors from service', async () => {
+    req.params = { runId: 'run1' };
+    (service.getTrackingStatus as jest.Mock).mockImplementation(() => {
+      throw new Error('bad');
+    });
+
+    await controller.getTrackingStatus(req as Request, res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Failed to get tracking status' });
+  });
+});

--- a/packages/tracking-service/src/api/controllers/tracking.controller.ts
+++ b/packages/tracking-service/src/api/controllers/tracking.controller.ts
@@ -43,8 +43,12 @@ export class TrackingController {
   async getTrackingStatus(req: Request, res: Response): Promise<void> {
     try {
       const { runId } = req.params;
-      // Implementation depends on how we store tracking status
-      res.status(200).json({ message: 'Tracking status retrieved' });
+      const status = this.trackingService.getTrackingStatus(runId);
+      if (!status) {
+        res.status(404).json({ error: 'Run not found' });
+        return;
+      }
+      res.status(200).json({ status });
     } catch (error) {
       console.error('Failed to get tracking status:', error);
       res.status(500).json({ error: 'Failed to get tracking status' });

--- a/packages/tracking-service/src/infra/services/tracking.service.ts
+++ b/packages/tracking-service/src/infra/services/tracking.service.ts
@@ -111,6 +111,10 @@ export class TrackingService {
     return this.activeRuns.get(runId)?.lastLocation;
   }
 
+  getTrackingStatus(runId: string): Run['status'] | undefined {
+    return this.activeRuns.get(runId)?.run.status;
+  }
+
   private async checkGeofences(location: Location): Promise<Geofence[]> {
     const point: GeolibCoordinates = {
       latitude: location.latitude,

--- a/packages/tracking-service/tsconfig.test.json
+++ b/packages/tracking-service/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@shared/*": ["../shared/src/*"],
+      "@send/shared": ["../shared/src"],
+      "@send/shared/*": ["../shared/src/*"],
+      "@prisma/client": ["../../test/prisma-client.ts"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- expose `getTrackingStatus` from `TrackingService`
- implement controller method for tracking status
- configure jest to use prisma client stub
- add unit tests for controller

## Testing
- `npm test` in `packages/tracking-service`

------
https://chatgpt.com/codex/tasks/task_e_68420df204b48333aeac859ce03ad88b