### PR TITLE
Implement WebSocket in-app provider

### DIFF
--- a/packages/system-notification-service/package.json
+++ b/packages/system-notification-service/package.json
@@ -22,7 +22,8 @@
     "winston": "^3.11.0",
     "firebase-admin": "^11.10.1",
     "nodemailer": "^6.9.9",
-    "twilio": "^4.15.2"
+    "twilio": "^4.15.2",
+    "socket.io-client": "^4.7.4"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
@@ -41,9 +42,10 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3",
     "@types/nodemailer": "^6.4.8",
-    "@types/twilio": "^3.19.3"
+    "@types/twilio": "^3.19.3",
+    "@types/socket.io-client": "^1.4.36"
   },
   "engines": {
     "node": ">=18.0.0"
   }
-} 
+}

--- a/packages/system-notification-service/src/__tests__/providers/inapp.provider.test.ts
+++ b/packages/system-notification-service/src/__tests__/providers/inapp.provider.test.ts
@@ -1,0 +1,62 @@
+import { InAppProvider } from "../../providers/inapp.provider";
+import {
+  NotificationChannel,
+  InAppNotification,
+  NotificationStatus,
+  NotificationPriority,
+} from "../../types/notification.types";
+import { Logger } from "winston";
+
+const mockEmit = jest.fn();
+const mockConnect = jest.fn();
+const mockOn = jest.fn();
+
+jest.mock("socket.io-client", () => ({
+  io: jest.fn(() => ({
+    emit: mockEmit,
+    connect: mockConnect,
+    on: mockOn,
+    connected: true,
+  })),
+}));
+
+const logger: Logger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+  log: jest.fn(),
+} as unknown as Logger;
+
+const sampleNotification: InAppNotification = {
+  id: "1",
+  userId: "u1",
+  title: "Hello",
+  message: "Message",
+  channel: NotificationChannel.IN_APP,
+  priority: NotificationPriority.LOW,
+  status: NotificationStatus.PENDING,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe("InAppProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("emits notification over websocket", async () => {
+    const provider = new InAppProvider(logger);
+    await provider.send(sampleNotification);
+    expect(mockEmit).toHaveBeenCalledWith("notification", sampleNotification);
+  });
+
+  it("logs and throws on error", async () => {
+    mockEmit.mockImplementation(() => {
+      throw new Error("fail");
+    });
+    const provider = new InAppProvider(logger);
+    await expect(provider.send(sampleNotification)).rejects.toThrow("fail");
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/packages/system-notification-service/src/providers/inapp.provider.ts
+++ b/packages/system-notification-service/src/providers/inapp.provider.ts
@@ -1,11 +1,33 @@
-import { InAppNotification } from '../types/notification.types';
-import { Logger } from 'winston';
+import { InAppNotification } from "../types/notification.types";
+import { Logger } from "winston";
+import { io, Socket } from "socket.io-client";
 
 export class InAppProvider {
-  constructor(private readonly logger: Logger) {}
+  private socket: Socket;
+
+  constructor(private readonly logger: Logger) {
+    const url = process.env.NOTIFICATION_WS_URL || "http://localhost:3000";
+    this.socket = io(url, { autoConnect: false });
+
+    this.socket.on("connect_error", (err) => {
+      this.logger.error("WebSocket connection error", { error: err });
+    });
+  }
 
   async send(notification: InAppNotification): Promise<void> {
-    this.logger.info('Sending in-app notification', { notification });
-    // Placeholder for real-time in-app notification delivery
+    this.logger.info("Sending in-app notification", { id: notification.id });
+    try {
+      if (!this.socket.connected) {
+        this.socket.connect();
+      }
+      this.socket.emit("notification", notification);
+      this.logger.info("In-app notification sent", { id: notification.id });
+    } catch (error) {
+      this.logger.error("Failed to send in-app notification", {
+        id: notification.id,
+        error,
+      });
+      throw error;
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
 
   packages/admin-service:
     dependencies:
+      '@prisma/client':
+        specifier: ^5.22.0
+        version: 5.22.0(prisma@5.22.0)
+      amqplib:
+        specifier: ^0.10.7
+        version: 0.10.7
       express:
         specifier: ^4.18.2
         version: 4.21.2
@@ -240,12 +246,21 @@ importers:
 
   packages/incident-service:
     dependencies:
+      '@prisma/client':
+        specifier: ^5.22.0
+        version: 5.22.0(prisma@5.22.0)
       express:
         specifier: ^4.18.2
         version: 4.21.2
+      node-cron:
+        specifier: ^4.1.0
+        version: 4.1.0
       shared:
         specifier: workspace:*
         version: link:../shared
+      winston:
+        specifier: ^3.11.0
+        version: 3.17.0
     devDependencies:
       '@types/express':
         specifier: ^4.17.21
@@ -256,6 +271,9 @@ importers:
       '@types/node':
         specifier: ^20.11.24
         version: 20.17.30
+      '@types/supertest':
+        specifier: ^6.0.2
+        version: 6.0.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.0.1
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
@@ -280,6 +298,12 @@ importers:
       prettier:
         specifier: ^3.2.5
         version: 3.5.3
+      prisma:
+        specifier: ^5.22.0
+        version: 5.22.0
+      supertest:
+        specifier: ^6.3.4
+        version: 6.3.4
       ts-jest:
         specifier: ^29.1.2
         version: 29.3.1(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.30)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3)))(typescript@5.8.3)
@@ -292,6 +316,12 @@ importers:
 
   packages/invoicing-service:
     dependencies:
+      '@prisma/client':
+        specifier: ^5.22.0
+        version: 5.22.0(prisma@5.22.0)
+      axios:
+        specifier: ^1.6.0
+        version: 1.8.4
       express:
         specifier: ^4.18.2
         version: 4.21.2
@@ -332,6 +362,9 @@ importers:
       prettier:
         specifier: ^3.2.5
         version: 3.5.3
+      prisma:
+        specifier: ^5.22.0
+        version: 5.22.0
       ts-jest:
         specifier: ^29.1.2
         version: 29.3.1(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.30)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3)))(typescript@5.8.3)
@@ -653,6 +686,9 @@ importers:
       shared:
         specifier: workspace:*
         version: link:../shared
+      socket.io-client:
+        specifier: ^4.7.4
+        version: 4.8.1
       twilio:
         specifier: ^4.15.2
         version: 4.23.0
@@ -669,6 +705,15 @@ importers:
       '@types/node':
         specifier: ^20.11.24
         version: 20.17.30
+      '@types/nodemailer':
+        specifier: ^6.4.8
+        version: 6.4.17
+      '@types/socket.io-client':
+        specifier: ^1.4.36
+        version: 1.4.36
+      '@types/twilio':
+        specifier: ^3.19.3
+        version: 3.19.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.0.1
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
@@ -2746,6 +2791,9 @@ packages:
   '@types/node@20.17.30':
     resolution: {integrity: sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==}
 
+  '@types/nodemailer@6.4.17':
+    resolution: {integrity: sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==}
+
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -2787,6 +2835,9 @@ packages:
   '@types/shimmer@1.2.0':
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
 
+  '@types/socket.io-client@1.4.36':
+    resolution: {integrity: sha512-ZJWjtFBeBy1kRSYpVbeGYTElf6BqPQUkXDlHHD4k/42byCN5Rh027f4yARHCink9sKAkbtGZXEAmR0ZCnc2/Ag==}
+
   '@types/socket.io@3.0.2':
     resolution: {integrity: sha512-pu0sN9m5VjCxBZVK8hW37ZcMe8rjn4HHggBN5CbaRTvFwv5jOmuIRZEuddsBPa9Th0ts0SIo3Niukq+95cMBbQ==}
     deprecated: This is a stub types definition. socket.io provides its own type definitions, so you do not need this installed.
@@ -2811,6 +2862,10 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/twilio@3.19.3':
+    resolution: {integrity: sha512-W53Z0TDCu6clZ5CzTWHRPnpQAad+AANglx6WiQ4Mkxxw21o4BYBx5EhkfR6J4iYqY58rtWB3r8kDGJ4y1uTUGQ==}
+    deprecated: This is a stub types definition. twilio provides its own type definitions, so you do not need this installed.
 
   '@types/validator@13.15.0':
     resolution: {integrity: sha512-nh7nrWhLr6CBq9ldtw0wx+z9wKnnv/uTVLA9g/3/TcOYxbpOSZE+MhKPmWqU+K0NvThjhv12uD8MuqijB0WzEA==}
@@ -3856,6 +3911,9 @@ packages:
 
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+
+  engine.io-client@6.6.3:
+    resolution: {integrity: sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==}
 
   engine.io-parser@5.2.3:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
@@ -6535,6 +6593,10 @@ packages:
   socket.io-adapter@2.5.5:
     resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
 
+  socket.io-client@4.8.1:
+    resolution: {integrity: sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==}
+    engines: {node: '>=10.0.0'}
+
   socket.io-parser@4.2.4:
     resolution: {integrity: sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==}
     engines: {node: '>=10.0.0'}
@@ -7328,6 +7390,10 @@ packages:
 
   xmlcreate@2.0.4:
     resolution: {integrity: sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==}
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   xorshift@1.2.0:
     resolution: {integrity: sha512-iYgNnGyeeJ4t6U11NpA/QiKy+PXn5Aa3Azg5qkwIFz1tBLllQrjjsk9yzD7IAK0naNU4JxdeDgqW9ov4u/hc4g==}
@@ -9849,6 +9915,10 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
+  '@types/nodemailer@6.4.17':
+    dependencies:
+      '@types/node': 20.17.30
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/opossum@8.1.8':
@@ -9898,6 +9968,8 @@ snapshots:
 
   '@types/shimmer@1.2.0': {}
 
+  '@types/socket.io-client@1.4.36': {}
+
   '@types/socket.io@3.0.2':
     dependencies:
       socket.io: 4.8.1
@@ -9930,6 +10002,13 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/twilio@3.19.3':
+    dependencies:
+      twilio: 4.23.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   '@types/validator@13.15.0': {}
 
@@ -11086,6 +11165,18 @@ snapshots:
   end-of-stream@1.4.4:
     dependencies:
       once: 1.4.0
+
+  engine.io-client@6.6.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.3.7
+      engine.io-parser: 5.2.3
+      ws: 8.17.1
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   engine.io-parser@5.2.3: {}
 
@@ -14524,6 +14615,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  socket.io-client@4.8.1:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.3.7
+      engine.io-client: 6.6.3
+      socket.io-parser: 4.2.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   socket.io-parser@4.2.4:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
@@ -15357,6 +15459,8 @@ snapshots:
 
   xmlcreate@2.0.4:
     optional: true
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   xorshift@1.2.0: {}
 


### PR DESCRIPTION
## Summary
- implement real-time websocket delivery in `InAppProvider`
- add socket.io dependencies
- test InAppProvider send logic

## Testing
- `pnpm --filter system-notification-service test` *(fails: Module 'amqplib' has no exported member 'Options')*

------
https://chatgpt.com/codex/tasks/task_e_68420df2bdc88333a35559bfd1619261