### PR TITLE
Update tracking-service port

### DIFF
--- a/packages/api-gateway/src/config.ts
+++ b/packages/api-gateway/src/config.ts
@@ -5,7 +5,7 @@ export const serviceConfig = {
   driverService: process.env.DRIVER_SERVICE_URL || 'http://localhost:3004',
   vehicleService: process.env.VEHICLE_SERVICE_URL || 'http://localhost:3005',
   documentService: process.env.DOCUMENT_SERVICE_URL || 'http://localhost:3006',
-  trackingService: process.env.TRACKING_SERVICE_URL || 'http://localhost:3003',
+  trackingService: process.env.TRACKING_SERVICE_URL || 'http://localhost:3007',
   incidentService: process.env.INCIDENT_SERVICE_URL || 'http://localhost:3010',
   invoicingService: process.env.INVOICING_SERVICE_URL || 'http://localhost:3011',
   adminService: process.env.ADMIN_SERVICE_URL || 'http://localhost:3012'

--- a/packages/tracking-service/.env.example
+++ b/packages/tracking-service/.env.example
@@ -1,4 +1,4 @@
-PORT=3003
+PORT=3007
 DATABASE_URL=postgresql://user:password@localhost:5432/send_tracking
 RABBITMQ_URL=amqp://localhost
 JWT_SECRET=your-secret-key

--- a/packages/tracking-service/README.md
+++ b/packages/tracking-service/README.md
@@ -102,7 +102,7 @@ pnpm test:coverage
 
 ## Environment Variables
 
-- `PORT` - Service port (default: 3003)
+- `PORT` - Service port (default: 3007)
 - `DATABASE_URL` - PostgreSQL connection string
 - `RABBITMQ_URL` - RabbitMQ connection string
 - `JWT_SECRET` - JWT secret for authentication

--- a/packages/tracking-service/src/index.ts
+++ b/packages/tracking-service/src/index.ts
@@ -80,7 +80,7 @@ async function start() {
       // Handle tracking events as needed
     });
 
-    const port = process.env.PORT || 3003;
+    const port = process.env.PORT || 3007;
     httpServer.listen(port, () => {
       console.log(`Tracking service listening on port ${port}`);
     });


### PR DESCRIPTION
## Summary
- update default port for tracking-service to 3007
- point API gateway's tracking service URL to the new port

## Testing
- `npm test` *(fails: Prisma schema validation error)*

------
https://chatgpt.com/codex/tasks/task_e_68420df5a120833395c28f4fce4ba779