### PR TITLE
Fix DB env variable in user-service

### DIFF
--- a/packages/user-service/.env.example
+++ b/packages/user-service/.env.example
@@ -3,7 +3,6 @@ NODE_ENV=development
 DB_HOST=localhost
 DB_PORT=5432
 DB_USERNAME=postgres
-DB_USER=postgres
 DB_PASSWORD=postgres
 DB_NAME=send_transport
 JWT_SECRET=your-secret-key

--- a/packages/user-service/src/data/data-source.ts
+++ b/packages/user-service/src/data/data-source.ts
@@ -5,7 +5,7 @@ export const AppDataSource = new DataSource({
   type: 'postgres',
   host: process.env.DB_HOST || 'localhost',
   port: parseInt(process.env.DB_PORT || '5432'),
-  username: process.env.DB_USER || 'postgres',
+  username: process.env.DB_USERNAME || 'postgres',
   password: process.env.DB_PASSWORD || 'postgres',
   database: process.env.DB_NAME || 'user_service',
   entities: [User],


### PR DESCRIPTION
## Summary
- update `AppDataSource` to use `DB_USERNAME`
- remove `DB_USER` from user-service example env file

## Testing
- `pnpm test` *(fails: Prisma schema validation error)*

------
https://chatgpt.com/codex/tasks/task_e_68420df4acd8833384e197771d4d5f29