### PR TITLE
Remove unused amqplib type

### DIFF
--- a/packages/shared/src/messaging/rabbitmq.service.ts
+++ b/packages/shared/src/messaging/rabbitmq.service.ts
@@ -1,4 +1,4 @@
-import { connect, Channel, Connection, Options } from 'amqplib';
+import { connect, Channel, Connection } from 'amqplib';
 import { Logger } from 'winston';
 
 export interface RabbitMQConfig {


### PR DESCRIPTION
## Summary
- clean up RabbitMQService import by removing unused `Options`

## Testing
- `pnpm --filter shared test`

------
https://chatgpt.com/codex/tasks/task_e_684351a0ca788333a19f643148ae3bb2