### PR TITLE
Centralize Jest configuration

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,0 +1,15 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  moduleNameMapper: {
+    '^@send/shared$': '<rootDir>/../shared/src',
+    '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
+    '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
+    '^@prisma/client$': '<rootDir>/../../test/prisma-client.ts',
+  },
+};

--- a/packages/admin-service/jest.config.js
+++ b/packages/admin-service/jest.config.js
@@ -1,14 +1,5 @@
+const base = require('../../jest.config.base');
+
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
-  transform: {
-    '^.+\\.ts$': 'ts-jest',
-  },
-  moduleNameMapper: {
-    '^@send/shared$': '<rootDir>/../shared/src',
-    '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@shared/(.*)$': '<rootDir>/../shared/src/$1'
-  }
+  ...base,
 };

--- a/packages/api-gateway/package.json
+++ b/packages/api-gateway/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/index.js",
     "dev": "nodemon src/index.ts",
     "build": "tsc",
-    "test": "jest --passWithNoTests",
+    "test": "jest",
     "lint": "eslint src/**/*.ts",
     "format": "prettier --write \"src/**/*.ts\""
   },

--- a/packages/document-service/jest.config.js
+++ b/packages/document-service/jest.config.js
@@ -1,21 +1,11 @@
+const base = require('../../jest.config.base');
+
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
-  transform: {
-    '^.+\\.ts$': 'ts-jest',
-  },
-  moduleNameMapper: {
-    '^@send/shared$': '<rootDir>/../shared/src',
-    '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@prisma/client$': '<rootDir>/../../test/prisma-client.ts'
-  },
+  ...base,
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.test.json'
-    }
+      tsconfig: '<rootDir>/tsconfig.test.json',
+    },
   },
   coverageDirectory: 'coverage',
   collectCoverageFrom: [

--- a/packages/driver-service/jest.config.js
+++ b/packages/driver-service/jest.config.js
@@ -1,21 +1,11 @@
+const base = require('../../jest.config.base');
+
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
-  transform: {
-    '^.+\\.ts$': 'ts-jest',
-  },
-  moduleNameMapper: {
-    '^@send/shared$': '<rootDir>/../shared/src',
-    '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@prisma/client$': '<rootDir>/../../test/prisma-client.ts'
-  },
+  ...base,
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.test.json'
-    }
+      tsconfig: '<rootDir>/tsconfig.test.json',
+    },
   },
   coverageDirectory: 'coverage',
   collectCoverageFrom: [

--- a/packages/incident-service/jest.config.js
+++ b/packages/incident-service/jest.config.js
@@ -1,14 +1,5 @@
+const base = require('../../jest.config.base');
+
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
-  transform: {
-    '^.+\\.ts$': 'ts-jest',
-  },
-  moduleNameMapper: {
-    '^@send/shared$': '<rootDir>/../shared/src',
-    '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@shared/(.*)$': '<rootDir>/../shared/src/$1'
-  }
+  ...base,
 };

--- a/packages/invoicing-service/jest.config.js
+++ b/packages/invoicing-service/jest.config.js
@@ -1,20 +1,10 @@
+const base = require('../../jest.config.base');
+
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
-  transform: {
-    '^.+\\.ts$': 'ts-jest',
-  },
-  moduleNameMapper: {
-    '^@send/shared$': '<rootDir>/../shared/src',
-    '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@prisma/client$': '<rootDir>/../../test/prisma-client.ts'
-  },
+  ...base,
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.test.json'
-    }
-  }
+      tsconfig: '<rootDir>/tsconfig.test.json',
+    },
+  },
 };

--- a/packages/run-service/jest.config.js
+++ b/packages/run-service/jest.config.js
@@ -1,21 +1,12 @@
+const base = require('../../jest.config.base');
+
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
+  ...base,
   testMatch: ['**/?(*.)+(test).ts'],
-  transform: {
-    '^.+\\.ts$': 'ts-jest',
-  },
-  moduleNameMapper: {
-    '^@send/shared$': '<rootDir>/../shared/src',
-    '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@prisma/client$': '<rootDir>/../../test/prisma-client.ts'
-  },
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.test.json'
-    }
+      tsconfig: '<rootDir>/tsconfig.test.json',
+    },
   },
   setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup.ts'],
   coverageDirectory: 'coverage',
@@ -25,4 +16,4 @@ module.exports = {
     '!src/index.ts',
     '!src/**/__tests__/**',
   ],
-}; 
+};

--- a/packages/shared/jest.config.js
+++ b/packages/shared/jest.config.js
@@ -1,19 +1,16 @@
+const base = require('../../jest.config.base');
+
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
+  ...base,
   testMatch: ['**/?(*.)+(test).ts'],
-  transform: {
-    '^.+\\.ts$': 'ts-jest'
-  },
   moduleNameMapper: {
     '^@send/shared$': '<rootDir>/src',
     '^@send/shared/(.*)$': '<rootDir>/src/$1',
-    '^@shared/(.*)$': '<rootDir>/src/$1'
+    '^@shared/(.*)$': '<rootDir>/src/$1',
   },
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.json'
-    }
-  }
+      tsconfig: '<rootDir>/tsconfig.json',
+    },
+  },
 };

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/index.js",
     "dev": "nodemon src/index.ts",
     "build": "tsc",
-    "test": "jest --passWithNoTests",
+    "test": "jest",
     "lint": "eslint src/**/*.ts",
     "format": "prettier --write \"src/**/*.ts\"",
     "prisma:generate": "prisma generate",

--- a/packages/student-service/jest.config.js
+++ b/packages/student-service/jest.config.js
@@ -1,21 +1,11 @@
+const base = require('../../jest.config.base');
+
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
-  transform: {
-    '^.+\\.ts$': 'ts-jest',
-  },
-  moduleNameMapper: {
-    '^@send/shared$': '<rootDir>/../shared/src',
-    '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@prisma/client$': '<rootDir>/../../test/prisma-client.ts'
-  },
+  ...base,
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.test.json'
-    }
+      tsconfig: '<rootDir>/tsconfig.test.json',
+    },
   },
   coverageDirectory: 'coverage',
   collectCoverageFrom: [

--- a/packages/system-notification-service/jest.config.js
+++ b/packages/system-notification-service/jest.config.js
@@ -1,21 +1,11 @@
+const base = require('../../jest.config.base');
+
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
-  transform: {
-    '^.+\\.ts$': 'ts-jest',
-  },
-  moduleNameMapper: {
-    '^@send/shared$': '<rootDir>/../../shared/src',
-    '^@send/shared/(.*)$': '<rootDir>/../../shared/src/$1',
-    '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@prisma/client$': '<rootDir>/../../test/prisma-client.ts'
-  },
+  ...base,
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.test.json'
-    }
+      tsconfig: '<rootDir>/tsconfig.test.json',
+    },
   },
   coverageDirectory: 'coverage',
   collectCoverageFrom: [

--- a/packages/tracking-service/jest.config.js
+++ b/packages/tracking-service/jest.config.js
@@ -1,21 +1,11 @@
+const base = require('../../jest.config.base');
+
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
-  transform: {
-    '^.+\\.ts$': 'ts-jest',
-  },
-  moduleNameMapper: {
-    '^@send/shared$': '<rootDir>/../shared/src',
-    '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@prisma/client$': '<rootDir>/../../test/prisma-client.ts'
-  },
+  ...base,
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.test.json'
-    }
+      tsconfig: '<rootDir>/tsconfig.test.json',
+    },
   },
   coverageDirectory: 'coverage',
   collectCoverageFrom: [

--- a/packages/user-service/jest.config.js
+++ b/packages/user-service/jest.config.js
@@ -1,21 +1,11 @@
+const base = require('../../jest.config.base');
+
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
-  transform: {
-    '^.+\\.ts$': 'ts-jest',
-  },
-  moduleNameMapper: {
-    '^@send/shared$': '<rootDir>/../shared/src',
-    '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@prisma/client$': '<rootDir>/../../test/prisma-client.ts'
-  },
+  ...base,
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.test.json'
-    }
+      tsconfig: '<rootDir>/tsconfig.test.json',
+    },
   },
   coverageDirectory: 'coverage',
   collectCoverageFrom: [

--- a/packages/user-service/package.json
+++ b/packages/user-service/package.json
@@ -10,7 +10,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
-    "test": "jest --passWithNoTests",
+    "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",

--- a/packages/vehicle-service/jest.config.js
+++ b/packages/vehicle-service/jest.config.js
@@ -1,15 +1,7 @@
+const base = require('../../jest.config.base');
+
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
+  ...base,
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  moduleNameMapper: {
-    '^@send/shared$': '<rootDir>/../shared/src',
-    '^@send/shared/(.*)$': '<rootDir>/../shared/src/$1',
-    '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
-  },
 };


### PR DESCRIPTION
## Summary
- introduce `jest.config.base.js` for common settings
- update service `jest.config.js` files to extend the base config
- unify `test` scripts across packages

## Testing
- `pnpm test` *(fails: Running target test for 13 projects failed)*

------
https://chatgpt.com/codex/tasks/task_e_68441dbd4e6c8333af37b79a785db9b8