### PR TITLE
Use standardized response helpers across services

### DIFF
--- a/packages/driver-service/src/api/controllers/driver.controller.ts
+++ b/packages/driver-service/src/api/controllers/driver.controller.ts
@@ -1,6 +1,8 @@
 import { Request, Response } from 'express';
 import { DriverService } from '../../infra/services/driver.service';
 import { Driver, DriverStatus } from '@shared/types/driver';
+import { createSuccessResponse, createErrorResponse } from '@shared/responses';
+import { AppError } from '@shared/errors';
 
 export class DriverController {
   constructor(private readonly driverService: DriverService) {}
@@ -9,10 +11,10 @@ export class DriverController {
     try {
       const driver = req.body as Omit<Driver, 'id' | 'createdAt' | 'updatedAt'>;
       const createdDriver = await this.driverService.createDriver(driver);
-      res.status(201).json(createdDriver);
+      res.status(201).json(createSuccessResponse(createdDriver));
     } catch (error) {
       console.error('Failed to create driver:', error);
-      res.status(500).json({ error: 'Failed to create driver' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 
@@ -21,10 +23,10 @@ export class DriverController {
       const { id } = req.params;
       const driver = req.body as Partial<Driver>;
       const updatedDriver = await this.driverService.updateDriver(id, driver);
-      res.status(200).json(updatedDriver);
+      res.status(200).json(createSuccessResponse(updatedDriver));
     } catch (error) {
       console.error('Failed to update driver:', error);
-      res.status(500).json({ error: 'Failed to update driver' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 
@@ -33,23 +35,23 @@ export class DriverController {
       const { id } = req.params;
       const driver = await this.driverService.getDriver(id);
       if (!driver) {
-        res.status(404).json({ error: 'Driver not found' });
+        res.status(404).json(createErrorResponse(new AppError('Driver not found', 404)));
         return;
       }
-      res.status(200).json(driver);
+      res.status(200).json(createSuccessResponse(driver));
     } catch (error) {
       console.error('Failed to get driver:', error);
-      res.status(500).json({ error: 'Failed to get driver' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 
   async getDrivers(req: Request, res: Response): Promise<void> {
     try {
       const drivers = await this.driverService.getDrivers();
-      res.status(200).json(drivers);
+      res.status(200).json(createSuccessResponse(drivers));
     } catch (error) {
       console.error('Failed to get drivers:', error);
-      res.status(500).json({ error: 'Failed to get drivers' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 
@@ -60,7 +62,7 @@ export class DriverController {
       res.status(204).send();
     } catch (error) {
       console.error('Failed to delete driver:', error);
-      res.status(500).json({ error: 'Failed to delete driver' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 
@@ -69,10 +71,10 @@ export class DriverController {
       const { id } = req.params;
       const { status } = req.body as { status: DriverStatus };
       const updatedDriver = await this.driverService.updateDriverStatus(id, status);
-      res.status(200).json(updatedDriver);
+      res.status(200).json(createSuccessResponse(updatedDriver));
     } catch (error) {
       console.error('Failed to update driver status:', error);
-      res.status(500).json({ error: 'Failed to update driver status' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 
@@ -81,10 +83,10 @@ export class DriverController {
       const { driverId } = req.params;
       const { runId } = req.body as { runId: string };
       const updatedDriver = await this.driverService.assignDriverToRun(driverId, runId);
-      res.status(200).json(updatedDriver);
+      res.status(200).json(createSuccessResponse(updatedDriver));
     } catch (error) {
       console.error('Failed to assign driver to run:', error);
-      res.status(500).json({ error: 'Failed to assign driver to run' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 
@@ -92,10 +94,10 @@ export class DriverController {
     try {
       const { driverId } = req.params;
       const updatedDriver = await this.driverService.unassignDriverFromRun(driverId);
-      res.status(200).json(updatedDriver);
+      res.status(200).json(createSuccessResponse(updatedDriver));
     } catch (error) {
       console.error('Failed to unassign driver from run:', error);
-      res.status(500).json({ error: 'Failed to unassign driver from run' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 
@@ -103,10 +105,10 @@ export class DriverController {
     try {
       const { id } = req.params;
       const availability = await this.driverService.getDriverAvailability(id);
-      res.status(200).json(availability);
+      res.status(200).json(createSuccessResponse(availability));
     } catch (error) {
       console.error('Failed to get driver availability:', error);
-      res.status(500).json({ error: 'Failed to get driver availability' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 
@@ -115,20 +117,20 @@ export class DriverController {
       const { id } = req.params;
       const slots = req.body as { startTime: Date; endTime: Date }[];
       const availability = await this.driverService.updateDriverAvailability(id, slots);
-      res.status(200).json(availability);
+      res.status(200).json(createSuccessResponse(availability));
     } catch (error) {
       console.error('Failed to update driver availability:', error);
-      res.status(500).json({ error: 'Failed to update driver availability' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 
   async getAvailableDrivers(req: Request, res: Response): Promise<void> {
     try {
       const drivers = await this.driverService.getAvailableDrivers();
-      res.status(200).json(drivers);
+      res.status(200).json(createSuccessResponse(drivers));
     } catch (error) {
       console.error('Failed to get available drivers:', error);
-      res.status(500).json({ error: 'Failed to get available drivers' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 
@@ -136,10 +138,10 @@ export class DriverController {
     try {
       const { driverId } = req.params;
       const performance = await this.driverService.getDriverPerformance(driverId);
-      res.status(200).json(performance);
+      res.status(200).json(createSuccessResponse(performance));
     } catch (error) {
       console.error('Failed to get driver performance:', error);
-      res.status(500).json({ error: 'Failed to get driver performance' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
-} 
+}

--- a/packages/run-service/src/api/middleware/error.middleware.ts
+++ b/packages/run-service/src/api/middleware/error.middleware.ts
@@ -1,4 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
+import { createErrorResponse } from '@shared/responses';
+import { AppError } from '@shared/errors';
 
 export const errorHandler = (
   err: Error,
@@ -9,21 +11,16 @@ export const errorHandler = (
   console.error(err.stack);
 
   if (err.name === 'ValidationError') {
-    return res.status(400).json({
-      error: 'Validation Error',
-      message: err.message,
-    });
+    return res
+      .status(400)
+      .json(createErrorResponse(new AppError(err.message, 400)));
   }
 
   if (err.name === 'UnauthorizedError') {
-    return res.status(401).json({
-      error: 'Unauthorized',
-      message: err.message,
-    });
+    return res
+      .status(401)
+      .json(createErrorResponse(new AppError(err.message, 401)));
   }
 
-  res.status(500).json({
-    error: 'Internal Server Error',
-    message: 'An unexpected error occurred',
-  });
-}; 
+  res.status(500).json(createErrorResponse(err));
+};

--- a/packages/run-service/src/app.ts
+++ b/packages/run-service/src/app.ts
@@ -9,6 +9,7 @@ import { RabbitMQService } from './infra/messaging/rabbitmq';
 import { RouteService } from './infra/services/route.service';
 import { ScheduleService } from './infra/services/schedule.service';
 import { createRunRoutes } from './api/routes/run.routes';
+import { createErrorResponse } from '@shared/responses';
 
 const app = express();
 const prisma = new PrismaClient();
@@ -40,7 +41,7 @@ app.use('/api/runs', createRunRoutes(runController));
 // Error handling middleware
 app.use((err: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {
   console.error(err.stack);
-  res.status(500).json({ error: 'Something went wrong!' });
+  res.status(500).json(createErrorResponse(err));
 });
 
 export default app; 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,3 +5,4 @@ export * from './testing/setup';
 export * from './messaging';
 export { PrismaClient } from '@prisma/client';
 export { authenticate, requireRole } from './security/auth';
+export * from './responses';

--- a/packages/shared/src/responses/index.ts
+++ b/packages/shared/src/responses/index.ts
@@ -1,0 +1,2 @@
+export * from './success';
+export * from './error';

--- a/packages/shared/src/security/middleware.ts
+++ b/packages/shared/src/security/middleware.ts
@@ -1,6 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 import { RateLimiter } from './rate-limiter';
 import { prometheus } from '../config/metrics';
+import { createErrorResponse } from '../responses';
+import { AppError } from '../errors';
 
 // Security headers middleware
 export const securityHeaders = (req: Request, res: Response, next: NextFunction) => {
@@ -92,21 +94,16 @@ export const errorHandler = (err: Error, req: Request, res: Response, next: Next
   console.error('Unhandled error:', err);
 
   if (err.name === 'ValidationError') {
-    return res.status(400).json({
-      error: 'Validation Error',
-      message: err.message
-    });
+    return res.status(400).json(
+      createErrorResponse(new AppError(err.message, 400))
+    );
   }
 
   if (err.name === 'UnauthorizedError') {
-    return res.status(401).json({
-      error: 'Unauthorized',
-      message: 'Invalid or missing authentication token'
-    });
+    return res.status(401).json(
+      createErrorResponse(new AppError('Invalid or missing authentication token', 401))
+    );
   }
 
-  res.status(500).json({
-    error: 'Internal Server Error',
-    message: 'An unexpected error occurred'
-  });
-}; 
+  res.status(500).json(createErrorResponse(err));
+};

--- a/packages/tracking-service/src/api/controllers/tracking.controller.ts
+++ b/packages/tracking-service/src/api/controllers/tracking.controller.ts
@@ -2,6 +2,8 @@ import { Request, Response } from 'express';
 import { TrackingService } from '../../infra/services/tracking.service';
 import { Run } from '@shared/types/run';
 import { Location } from '@shared/types/tracking';
+import { createSuccessResponse, createErrorResponse } from '@shared/responses';
+import { AppError } from '@shared/errors';
 
 export class TrackingController {
   constructor(private readonly trackingService: TrackingService) {}
@@ -10,10 +12,10 @@ export class TrackingController {
     try {
       const run = req.body as Run;
       await this.trackingService.startTracking(run);
-      res.status(200).json({ message: 'Tracking started' });
+      res.status(200).json(createSuccessResponse({ message: 'Tracking started' }));
     } catch (error) {
       console.error('Failed to start tracking:', error);
-      res.status(500).json({ error: 'Failed to start tracking' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 
@@ -22,10 +24,10 @@ export class TrackingController {
       const { runId } = req.params;
       const location = req.body as Location;
       await this.trackingService.updateLocation(runId, location);
-      res.status(200).json({ message: 'Location updated' });
+      res.status(200).json(createSuccessResponse({ message: 'Location updated' }));
     } catch (error) {
       console.error('Failed to update location:', error);
-      res.status(500).json({ error: 'Failed to update location' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 
@@ -33,10 +35,10 @@ export class TrackingController {
     try {
       const { runId } = req.params;
       await this.trackingService.stopTracking(runId);
-      res.status(200).json({ message: 'Tracking stopped' });
+      res.status(200).json(createSuccessResponse({ message: 'Tracking stopped' }));
     } catch (error) {
       console.error('Failed to stop tracking:', error);
-      res.status(500).json({ error: 'Failed to stop tracking' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 
@@ -45,13 +47,13 @@ export class TrackingController {
       const { runId } = req.params;
       const status = this.trackingService.getTrackingStatus(runId);
       if (!status) {
-        res.status(404).json({ error: 'Run not found' });
+        res.status(404).json(createErrorResponse(new AppError('Run not found', 404)));
         return;
       }
-      res.status(200).json({ status });
+      res.status(200).json(createSuccessResponse({ status }));
     } catch (error) {
       console.error('Failed to get tracking status:', error);
-      res.status(500).json({ error: 'Failed to get tracking status' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 
@@ -60,17 +62,19 @@ export class TrackingController {
       const { routeId } = req.params;
       const location = this.trackingService.getLatestLocation(routeId);
       if (!location) {
-        res.status(404).json({ error: 'Location not found' });
+        res.status(404).json(createErrorResponse(new AppError('Location not found', 404)));
         return;
       }
-      res.status(200).json({
-        lat: location.latitude,
-        lng: location.longitude,
-        timestamp: location.timestamp,
-      });
+      res.status(200).json(
+        createSuccessResponse({
+          lat: location.latitude,
+          lng: location.longitude,
+          timestamp: location.timestamp,
+        })
+      );
     } catch (error) {
       console.error('Failed to get latest location:', error);
-      res.status(500).json({ error: 'Failed to get latest location' });
+      res.status(500).json(createErrorResponse(error as Error));
     }
   }
 }

--- a/packages/user-service/src/api/middleware/error.middleware.ts
+++ b/packages/user-service/src/api/middleware/error.middleware.ts
@@ -1,4 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
+import { createErrorResponse } from '@shared/responses';
+import { AppError } from '@shared/errors';
 
 export const errorHandler = (
   err: Error,
@@ -9,21 +11,14 @@ export const errorHandler = (
   console.error(err.stack);
 
   if (err.name === 'ValidationError') {
-    return res.status(400).json({
-      error: 'Validation Error',
-      message: err.message,
-    });
+    return res.status(400).json(createErrorResponse(new AppError(err.message, 400)));
   }
 
   if (err.name === 'UnauthorizedError') {
-    return res.status(401).json({
-      error: 'Unauthorized',
-      message: 'Invalid or expired token',
-    });
+    return res.status(401).json(
+      createErrorResponse(new AppError('Invalid or expired token', 401))
+    );
   }
 
-  res.status(500).json({
-    error: 'Internal Server Error',
-    message: process.env.NODE_ENV === 'development' ? err.message : undefined,
-  });
-}; 
+  res.status(500).json(createErrorResponse(err));
+};

--- a/packages/user-service/src/api/middleware/errorHandler.ts
+++ b/packages/user-service/src/api/middleware/errorHandler.ts
@@ -1,4 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
+import { createErrorResponse } from '@shared/responses';
+import { AppError as SharedAppError } from '@shared/errors';
 
 export class AppError extends Error {
   constructor(
@@ -17,17 +19,12 @@ export const errorHandler = (
   res: Response,
   next: NextFunction
 ) => {
-  if (err instanceof AppError) {
-    return res.status(err.statusCode).json({
-      status: 'error',
-      message: err.message,
-    });
+  if (err instanceof AppError || err instanceof SharedAppError) {
+    const status = (err as any).statusCode;
+    return res.status(status).json(createErrorResponse(err));
   }
 
   // Handle unexpected errors
   console.error('Unexpected error:', err);
-  return res.status(500).json({
-    status: 'error',
-    message: 'Internal server error',
-  });
-}; 
+  return res.status(500).json(createErrorResponse(err));
+};

--- a/packages/user-service/src/middleware/errorHandler.ts
+++ b/packages/user-service/src/middleware/errorHandler.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { prometheus } from '@shared/prometheus';
 import { logger } from '../services/logging.service';
+import { createErrorResponse } from '@shared/responses';
 
 export const errorHandler = (
   err: Error,
@@ -24,10 +25,7 @@ export const errorHandler = (
   });
 
   // Send error response
-  res.status(500).json({
-    status: 'error',
-    message: process.env.NODE_ENV === 'production' 
-      ? 'Internal server error' 
-      : err.message
-  });
-}; 
+  res
+    .status(500)
+    .json(createErrorResponse(err));
+};


### PR DESCRIPTION
## Summary
- export success and error response helpers from shared package
- use `createSuccessResponse`/`createErrorResponse` in tracking, driver and run services
- update error middleware across services to return uniform JSON

## Testing
- `npm test` *(fails: Running target test for 13 projects failed)*

------
https://chatgpt.com/codex/tasks/task_e_68441daf4bf883338f546ddd20061927