### PR TITLE
Update middleware order

### DIFF
--- a/packages/admin-service/src/app.ts
+++ b/packages/admin-service/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import compression from 'compression';
+import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { AdminController } from './api/controllers/admin.controller';
 import { createAdminRoutes } from './api/routes/admin.routes';
 import { MetricsService } from './services/metrics.service';
@@ -14,10 +15,12 @@ const reportService = new ReportService(metricsService);
 const controller = new AdminController(metricsService, configService, reportService);
 
 const app = express();
-app.use(express.json());
+app.use(securityHeaders);
 app.use(cors());
 app.use(helmet());
 app.use(compression());
+app.use(express.json());
+app.use(rateLimit('admin-service'));
 
 app.use('/api', createAdminRoutes(controller));
 

--- a/packages/document-service/src/app.ts
+++ b/packages/document-service/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import compression from 'compression';
+import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { PrismaClient } from '@prisma/client';
 import { DocumentController } from './api/controllers/document.controller';
 import { DocumentService } from './services/document.service';
@@ -34,10 +35,12 @@ const documentController = new DocumentController(documentService);
 const healthCheckService = new HealthCheckService(prisma, rabbitMQ.getChannel(), logger.getLogger(), 'document-service');
 
 // Middleware
-app.use(express.json());
+app.use(securityHeaders);
 app.use(cors());
 app.use(helmet());
 app.use(compression());
+app.use(express.json());
+app.use(rateLimit('document-service'));
 
 // Routes
 app.use('/api/documents', createDocumentRoutes(documentController));

--- a/packages/incident-service/src/app.ts
+++ b/packages/incident-service/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import compression from 'compression';
+import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { PrismaClient } from '@prisma/client';
 import { IncidentService } from './services/incident.service';
 import { IncidentController } from './api/controllers/incident.controller';
@@ -28,10 +29,12 @@ export const incidentService = new IncidentService(prisma);
 const incidentController = new IncidentController(incidentService);
 
 const app = express();
-app.use(express.json());
+app.use(securityHeaders);
 app.use(cors());
 app.use(helmet());
 app.use(compression());
+app.use(express.json());
+app.use(rateLimit('incident-service'));
 
 app.use('/api/incidents', createIncidentRoutes(incidentController));
 

--- a/packages/invoicing-service/src/app.ts
+++ b/packages/invoicing-service/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import compression from 'compression';
+import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { PrismaClient } from '@prisma/client';
 import { InvoiceService } from './services/invoice.service';
 import { InvoiceController } from './api/controllers/invoice.controller';
@@ -12,10 +13,12 @@ export const invoiceService = new InvoiceService(prisma);
 const invoiceController = new InvoiceController(invoiceService);
 
 const app = express();
-app.use(express.json());
+app.use(securityHeaders);
 app.use(cors());
 app.use(helmet());
 app.use(compression());
+app.use(express.json());
+app.use(rateLimit('invoicing-service'));
 
 app.use('/api/invoices', createInvoiceRoutes(invoiceController));
 

--- a/packages/run-service/src/app.ts
+++ b/packages/run-service/src/app.ts
@@ -2,6 +2,7 @@ import express, { ErrorRequestHandler } from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import compression from 'compression';
+import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { PrismaClient } from '@prisma/client';
 import { RunModel } from './data/models/run.model';
 import { RunController } from './api/controllers/run.controller';
@@ -22,10 +23,12 @@ const scheduleService = new ScheduleService();
 rabbitMQ.connect().catch(console.error);
 
 // Middleware
-app.use(helmet());
+app.use(securityHeaders);
 app.use(cors());
+app.use(helmet());
 app.use(compression());
 app.use(express.json());
+app.use(rateLimit('run-service'));
 
 // Initialize controller with all services
 const runController = new RunController(

--- a/packages/student-service/src/app.ts
+++ b/packages/student-service/src/app.ts
@@ -1,13 +1,20 @@
 import express from 'express';
 import cors from 'cors';
+import helmet from 'helmet';
+import compression from 'compression';
+import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import studentRoutes from './api/routes/student.routes';
 import { errorHandler } from '@shared/errors';
 
 const app = express();
 
 // Middleware
+app.use(securityHeaders);
 app.use(cors());
+app.use(helmet());
+app.use(compression());
 app.use(express.json());
+app.use(rateLimit('student-service'));
 
 // Routes
 app.use('/api/students', studentRoutes);

--- a/packages/user-service/src/app.ts
+++ b/packages/user-service/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import compression from 'compression';
+import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import promBundle from 'express-prom-bundle';
 import { MonitoringService } from './infra/monitoring/monitoring.service';
 import { LoggingService } from 'shared/src/services/logging.service';
@@ -21,10 +22,12 @@ const metricsMiddleware = promBundle({
 });
 
 // Middleware
-app.use(helmet());
+app.use(securityHeaders);
 app.use(cors());
+app.use(helmet());
 app.use(compression() as unknown as express.RequestHandler);
 app.use(express.json());
+app.use(rateLimit('user-service'));
 app.use((req, res, next) => {
   logger.info('Incoming request', { method: req.method, url: req.url, ip: req.ip });
   next();

--- a/packages/vehicle-service/src/index.ts
+++ b/packages/vehicle-service/src/index.ts
@@ -1,6 +1,10 @@
 import express from 'express';
 import { Server } from 'http';
 import { PrismaClient } from '@prisma/client';
+import cors from 'cors';
+import helmet from 'helmet';
+import compression from 'compression';
+import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { VehicleService } from './services/vehicle.service';
 import { VehicleController } from './api/controllers/vehicle.controller';
 import { createVehicleRoutes } from './api/routes/vehicle.routes';
@@ -19,7 +23,12 @@ const vehicleService = new VehicleService(rabbitMQService);
 const vehicleController = new VehicleController(vehicleService);
 
 // Middleware
+app.use(securityHeaders);
+app.use(cors());
+app.use(helmet());
+app.use(compression());
 app.use(express.json());
+app.use(rateLimit('vehicle-service'));
 app.use('/api', createVehicleRoutes(vehicleController));
 
 // Start the service


### PR DESCRIPTION
## Summary
- apply shared securityHeaders and rateLimit middleware across services
- standardize middleware order in each service entry file

## Testing
- `pnpm build` *(fails: tasks not run because dependencies failed)*
- `pnpm --filter admin-service build` *(fails: rootDir errors)*

------
https://chatgpt.com/codex/tasks/task_e_68445ba8f1088333b017fb6a17b89ac6