### PR TITLE
Standardize service bootstrapping

### DIFF
--- a/packages/admin-service/src/index.ts
+++ b/packages/admin-service/src/index.ts
@@ -1,5 +1,7 @@
 import app from './app';
-import { logger } from '@shared/logger';
+import { LoggerService } from '@send/shared';
+
+const logger = new LoggerService({ serviceName: 'admin-service' });
 
 const port = process.env.PORT || 3012;
 

--- a/packages/admin-service/src/services/metrics.service.ts
+++ b/packages/admin-service/src/services/metrics.service.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import { RabbitMQService } from '@shared/messaging/rabbitmq.service';
-import { LoggingService } from '@shared/services/logging.service';
+import { databaseService, LoggerService } from '@send/shared';
 
 interface Metrics {
   totalRunsToday: number;
@@ -14,15 +14,11 @@ export class MetricsService {
   private documentDb: PrismaClient;
   private openIncidents = 0;
   private rabbit: RabbitMQService;
-  private logger = new LoggingService('admin-service');
+  private logger = new LoggerService({ serviceName: 'admin-service' });
 
   constructor() {
-    this.runDb = new PrismaClient({
-      datasources: { db: { url: process.env.RUN_DATABASE_URL! } }
-    });
-    this.documentDb = new PrismaClient({
-      datasources: { db: { url: process.env.DOCUMENT_DATABASE_URL! } }
-    });
+    this.runDb = databaseService.getPrismaClient();
+    this.documentDb = databaseService.getPrismaClient();
 
     this.rabbit = new RabbitMQService(
       {

--- a/packages/document-service/src/app.ts
+++ b/packages/document-service/src/app.ts
@@ -4,7 +4,7 @@ import helmet from 'helmet';
 import compression from 'compression';
 import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
-import { PrismaClient } from '@prisma/client';
+import { databaseService } from '@send/shared';
 import { DocumentController } from './api/controllers/document.controller';
 import { DocumentService } from './services/document.service';
 import { HealthCheckService } from '@shared/health/health.check';
@@ -16,7 +16,7 @@ import { createErrorResponse } from '@shared/responses';
 import { MonitoringService } from '@send/shared';
 
 const app = express();
-const prisma = new PrismaClient();
+const prisma = databaseService.getPrismaClient();
 
 // Initialize services
 const logger = new LoggerService({

--- a/packages/driver-service/src/api/controllers/driver.controller.ts
+++ b/packages/driver-service/src/api/controllers/driver.controller.ts
@@ -1,7 +1,10 @@
 import { Request, Response } from 'express';
 import { DriverService } from '../../infra/services/driver.service';
 import { Driver, DriverStatus } from '@shared/types/driver';
-import { logger } from '@shared/logger';
+import { LoggerService } from '@send/shared';
+import { createErrorResponse, AppError } from '@send/shared';
+
+const logger = new LoggerService({ serviceName: 'driver-service' });
 
 export class DriverController {
   constructor(private readonly driverService: DriverService) {}
@@ -13,7 +16,7 @@ export class DriverController {
       res.status(201).json(createdDriver);
     } catch (error) {
       logger.error('Failed to create driver:', error);
-      res.status(500).json({ error: 'Failed to create driver' });
+      res.status(500).json(createErrorResponse(new AppError('Failed to create driver', 500)));
     }
   }
 
@@ -25,7 +28,7 @@ export class DriverController {
       res.status(200).json(updatedDriver);
     } catch (error) {
       logger.error('Failed to update driver:', error);
-      res.status(500).json({ error: 'Failed to update driver' });
+      res.status(500).json(createErrorResponse(new AppError('Failed to update driver', 500)));
     }
   }
 
@@ -34,13 +37,13 @@ export class DriverController {
       const { id } = req.params;
       const driver = await this.driverService.getDriver(id);
       if (!driver) {
-        res.status(404).json({ error: 'Driver not found' });
+        res.status(404).json(createErrorResponse(new AppError('Driver not found', 404)));
         return;
       }
       res.status(200).json(driver);
     } catch (error) {
       logger.error('Failed to get driver:', error);
-      res.status(500).json({ error: 'Failed to get driver' });
+      res.status(500).json(createErrorResponse(new AppError('Failed to get driver', 500)));
     }
   }
 
@@ -50,7 +53,7 @@ export class DriverController {
       res.status(200).json(drivers);
     } catch (error) {
       logger.error('Failed to get drivers:', error);
-      res.status(500).json({ error: 'Failed to get drivers' });
+      res.status(500).json(createErrorResponse(new AppError('Failed to get drivers', 500)));
     }
   }
 
@@ -61,7 +64,7 @@ export class DriverController {
       res.status(204).send();
     } catch (error) {
       logger.error('Failed to delete driver:', error);
-      res.status(500).json({ error: 'Failed to delete driver' });
+      res.status(500).json(createErrorResponse(new AppError('Failed to delete driver', 500)));
     }
   }
 
@@ -73,7 +76,7 @@ export class DriverController {
       res.status(200).json(updatedDriver);
     } catch (error) {
       logger.error('Failed to update driver status:', error);
-      res.status(500).json({ error: 'Failed to update driver status' });
+      res.status(500).json(createErrorResponse(new AppError('Failed to update driver status', 500)));
     }
   }
 
@@ -85,7 +88,7 @@ export class DriverController {
       res.status(200).json(updatedDriver);
     } catch (error) {
       logger.error('Failed to assign driver to run:', error);
-      res.status(500).json({ error: 'Failed to assign driver to run' });
+      res.status(500).json(createErrorResponse(new AppError('Failed to assign driver to run', 500)));
     }
   }
 
@@ -96,7 +99,7 @@ export class DriverController {
       res.status(200).json(updatedDriver);
     } catch (error) {
       logger.error('Failed to unassign driver from run:', error);
-      res.status(500).json({ error: 'Failed to unassign driver from run' });
+      res.status(500).json(createErrorResponse(new AppError('Failed to unassign driver from run', 500)));
     }
   }
 
@@ -107,7 +110,7 @@ export class DriverController {
       res.status(200).json(availability);
     } catch (error) {
       logger.error('Failed to get driver availability:', error);
-      res.status(500).json({ error: 'Failed to get driver availability' });
+      res.status(500).json(createErrorResponse(new AppError('Failed to get driver availability', 500)));
     }
   }
 
@@ -119,7 +122,7 @@ export class DriverController {
       res.status(200).json(availability);
     } catch (error) {
       logger.error('Failed to update driver availability:', error);
-      res.status(500).json({ error: 'Failed to update driver availability' });
+      res.status(500).json(createErrorResponse(new AppError('Failed to update driver availability', 500)));
     }
   }
 
@@ -129,7 +132,7 @@ export class DriverController {
       res.status(200).json(drivers);
     } catch (error) {
       logger.error('Failed to get available drivers:', error);
-      res.status(500).json({ error: 'Failed to get available drivers' });
+      res.status(500).json(createErrorResponse(new AppError('Failed to get available drivers', 500)));
     }
   }
 
@@ -140,7 +143,7 @@ export class DriverController {
       res.status(200).json(performance);
     } catch (error) {
       logger.error('Failed to get driver performance:', error);
-      res.status(500).json({ error: 'Failed to get driver performance' });
+      res.status(500).json(createErrorResponse(new AppError('Failed to get driver performance', 500)));
     }
   }
 }

--- a/packages/incident-service/src/api/controllers/incident.controller.ts
+++ b/packages/incident-service/src/api/controllers/incident.controller.ts
@@ -1,5 +1,8 @@
 import { Request, Response } from 'express';
 import { IncidentService } from '../../services/incident.service';
+import { LoggerService, createErrorResponse, AppError } from '@send/shared';
+
+const logger = new LoggerService({ serviceName: 'incident-service' });
 
 export class IncidentController {
   constructor(private readonly incidentService: IncidentService) {}
@@ -9,7 +12,8 @@ export class IncidentController {
       const incident = await this.incidentService.createIncident(req.body);
       res.status(201).json(incident);
     } catch (err) {
-      res.status(500).json({ error: 'Failed to create incident' });
+      logger.error('Failed to create incident', { error: err });
+      res.status(500).json(createErrorResponse(new AppError('Failed to create incident', 500)));
     }
   }
 
@@ -21,7 +25,7 @@ export class IncidentController {
   async getById(req: Request, res: Response): Promise<void> {
     const incident = await this.incidentService.getIncident(req.params.id);
     if (!incident) {
-      res.status(404).json({ error: 'Incident not found' });
+      res.status(404).json(createErrorResponse(new AppError('Incident not found', 404)));
       return;
     }
     res.json(incident);
@@ -30,7 +34,7 @@ export class IncidentController {
   async update(req: Request, res: Response): Promise<void> {
     const incident = await this.incidentService.updateIncident(req.params.id, req.body);
     if (!incident) {
-      res.status(404).json({ error: 'Incident not found' });
+      res.status(404).json(createErrorResponse(new AppError('Incident not found', 404)));
       return;
     }
     res.json(incident);
@@ -39,7 +43,7 @@ export class IncidentController {
   async remove(req: Request, res: Response): Promise<void> {
     const deleted = await this.incidentService.deleteIncident(req.params.id);
     if (!deleted) {
-      res.status(404).json({ error: 'Incident not found' });
+      res.status(404).json(createErrorResponse(new AppError('Incident not found', 404)));
       return;
     }
     res.status(204).send();

--- a/packages/incident-service/src/app.ts
+++ b/packages/incident-service/src/app.ts
@@ -4,16 +4,15 @@ import helmet from 'helmet';
 import compression from 'compression';
 import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
-import { PrismaClient } from '@prisma/client';
+import { databaseService, LoggerService, HealthCheckService } from '@send/shared';
 import { IncidentService } from './services/incident.service';
 import { IncidentController } from './api/controllers/incident.controller';
 import { createIncidentRoutes } from './api/routes/incident.routes';
 import { RabbitMQService } from '@shared/messaging/rabbitmq.service';
-import { LoggerService } from '@shared/logging/logger.service';
 import { startEscalationJob } from './jobs/escalation.job';
 import { MonitoringService } from '@send/shared';
 
-export const prisma = new PrismaClient();
+export const prisma = databaseService.getPrismaClient();
 export const logger = new LoggerService({
   serviceName: 'incident-service',
   logLevel: process.env.LOG_LEVEL || 'info'
@@ -26,6 +25,8 @@ export const rabbitMQ = new RabbitMQService(
   },
   logger.getLogger()
 );
+
+const healthCheck = new HealthCheckService(prisma, rabbitMQ.getChannel(), logger.getLogger(), 'incident-service');
 
 export const incidentService = new IncidentService(prisma);
 const incidentController = new IncidentController(incidentService);
@@ -40,6 +41,11 @@ app.use(express.json());
 app.use(rateLimit('incident-service'));
 
 app.use('/api/incidents', createIncidentRoutes(incidentController));
+
+app.get('/health', async (_req, res) => {
+  const health = await healthCheck.checkHealth();
+  res.status(health.status === 'UP' ? 200 : 503).json(health);
+});
 
 const monitoringService = MonitoringService.getInstance();
 app.get('/metrics', async (_req, res) => {

--- a/packages/incident-service/src/index.ts
+++ b/packages/incident-service/src/index.ts
@@ -1,5 +1,4 @@
-import { app, rabbitMQ, prisma, logger as loggerService } from './app';
-import { logger } from '@shared/logger';
+import { app, rabbitMQ, prisma, logger } from './app';
 
 const port = process.env.PORT || 3010;
 
@@ -10,15 +9,18 @@ async function start() {
       logger.info(`Incident service running on port ${port}`);
     });
   } catch (err) {
-    loggerService.error('Failed to start incident service', { error: err });
+    logger.error('Failed to start incident service', { error: err });
     process.exit(1);
   }
 }
 
 start();
 
-process.on('SIGTERM', async () => {
+async function shutdown() {
   await rabbitMQ.close();
   await prisma.$disconnect();
   process.exit(0);
-});
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/packages/invoicing-service/src/index.ts
+++ b/packages/invoicing-service/src/index.ts
@@ -1,17 +1,14 @@
-import { app, prisma } from './app';
-import { logger } from '@shared/logger';
+import { app, prisma, logger } from './app';
 
 const port = process.env.PORT || 3011;
 
-process.on('SIGTERM', async () => {
+async function shutdown() {
   await prisma.$disconnect();
   process.exit(0);
-});
+}
 
-process.on('SIGINT', async () => {
-  await prisma.$disconnect();
-  process.exit(0);
-});
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
 
 app.listen(port, () => {
   logger.info(`Invoicing service running on port ${port}`);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,8 @@
 
 
 export * from './monitoring';
+export * from './db/database.service';
+export * from './logging/logger.service';
+export * from './health/health.check';
+export * from './responses';
 

--- a/packages/student-service/src/server.ts
+++ b/packages/student-service/src/server.ts
@@ -1,17 +1,20 @@
 import 'dotenv/config';
 import app from './app';
-import { PrismaClient } from '@prisma/client';
-import { logger } from '@shared/logger';
+import { databaseService, LoggerService } from '@send/shared';
 
-const prisma = new PrismaClient();
+const prisma = databaseService.getPrismaClient();
+const logger = new LoggerService({ serviceName: 'student-service' });
 const port = process.env.PORT || 3003;
 
 // Graceful shutdown
-process.on('SIGTERM', async () => {
-  logger.info('SIGTERM received. Shutting down gracefully...');
+async function shutdown() {
+  logger.info('Shutting down gracefully...');
   await prisma.$disconnect();
   process.exit(0);
-});
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
 
 // Start server
 app.listen(port, () => {

--- a/packages/user-service/src/app.ts
+++ b/packages/user-service/src/app.ts
@@ -8,14 +8,14 @@ import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
 
 import promBundle from 'express-prom-bundle';
 import { MonitoringService } from './infra/monitoring/monitoring.service';
-import { LoggingService } from '@shared/services/logging.service';
+import { LoggerService } from '@send/shared';
 
 
 import userRoutes from './api/routes/user.routes';
 import { errorHandler } from '@shared/errors';
 
 const app: express.Application = express();
-const logger = new LoggingService('user-service');
+const logger = new LoggerService({ serviceName: 'user-service' });
 
 // Initialize monitoring
 const monitoringService = MonitoringService.getInstance();

--- a/packages/user-service/src/index.ts
+++ b/packages/user-service/src/index.ts
@@ -6,11 +6,11 @@ import { errorHandler } from '@shared/errors';
 import { authRoutes } from './api/routes/auth.routes';
 import userRoutes from './api/routes/user.routes';
 import { setupEventBus } from './infra/eventBus';
-import { LoggingService } from '@shared/services/logging.service';
+import { LoggerService } from '@send/shared';
 import { createConnection } from 'mongoose';
 
 const app = express();
-const logger = new LoggingService('user-service');
+const logger = new LoggerService({ serviceName: 'user-service' });
 
 // Middleware
 app.use(helmet());


### PR DESCRIPTION
## Summary
- re-export key helpers in shared index
- migrate services to use DatabaseService singleton
- switch logging to LoggerService
- add consistent health checks and shutdowns
- adopt structured error responses in driver service

## Testing
- `pnpm test` *(fails: Prisma install step only)*
- `pnpm lint` *(fails: missing eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_68447d675ea48333b165ae1d23a9c36f