### PR TITLE
Standardize middleware order

### DIFF
--- a/packages/admin-service/src/app.ts
+++ b/packages/admin-service/src/app.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import cors from 'cors';
-import helmet from 'helmet';
 import compression from 'compression';
 import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
@@ -21,7 +20,6 @@ const app = express();
 app.use(securityHeaders);
 app.use(ipRateLimitMiddleware());
 app.use(cors());
-app.use(helmet());
 app.use(compression());
 app.use(express.json());
 app.use(rateLimit('admin-service'));

--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -1,5 +1,7 @@
 import express from 'express';
 import { createProxyMiddleware } from 'http-proxy-middleware';
+import cors from 'cors';
+import compression from 'compression';
 import { authenticate } from '@send/shared';
 import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
@@ -55,9 +57,11 @@ function createResilientProxy(target: string, serviceName: string) {
 
 const app = express();
 
-app.use(express.json());
 app.use(securityHeaders);
 app.use(ipRateLimitMiddleware());
+app.use(cors());
+app.use(compression());
+app.use(express.json());
 app.use(rateLimit('api-gateway'));
 
 // Request/response logging

--- a/packages/document-service/src/app.ts
+++ b/packages/document-service/src/app.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import cors from 'cors';
-import helmet from 'helmet';
 import compression from 'compression';
 import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
@@ -42,7 +41,6 @@ const healthCheckService = new HealthCheckService(prisma, rabbitMQ.getChannel(),
 app.use(securityHeaders);
 app.use(ipRateLimitMiddleware());
 app.use(cors());
-app.use(helmet());
 app.use(compression());
 app.use(express.json());
 app.use(rateLimit('document-service'));

--- a/packages/incident-service/src/app.ts
+++ b/packages/incident-service/src/app.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import cors from 'cors';
-import helmet from 'helmet';
 import compression from 'compression';
 import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
@@ -35,7 +34,6 @@ const app = express();
 app.use(securityHeaders);
 app.use(ipRateLimitMiddleware());
 app.use(cors());
-app.use(helmet());
 app.use(compression());
 app.use(express.json());
 app.use(rateLimit('incident-service'));

--- a/packages/invoicing-service/src/app.ts
+++ b/packages/invoicing-service/src/app.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import cors from 'cors';
-import helmet from 'helmet';
 import compression from 'compression';
 import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
@@ -20,7 +19,6 @@ const app = express();
 app.use(securityHeaders);
 app.use(ipRateLimitMiddleware());
 app.use(cors());
-app.use(helmet());
 app.use(compression());
 app.use(express.json());
 app.use(rateLimit('invoicing-service'));

--- a/packages/run-service/src/app.ts
+++ b/packages/run-service/src/app.ts
@@ -1,6 +1,5 @@
 import express, { ErrorRequestHandler } from 'express';
 import cors from 'cors';
-import helmet from 'helmet';
 import compression from 'compression';
 import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
@@ -30,7 +29,6 @@ rabbitMQ.connect().catch(console.error);
 app.use(securityHeaders);
 app.use(ipRateLimitMiddleware());
 app.use(cors());
-app.use(helmet());
 app.use(compression());
 app.use(express.json());
 app.use(rateLimit('run-service'));

--- a/packages/student-service/src/app.ts
+++ b/packages/student-service/src/app.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import cors from 'cors';
-import helmet from 'helmet';
 import compression from 'compression';
 import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
@@ -15,7 +14,6 @@ const app = express();
 app.use(securityHeaders);
 app.use(ipRateLimitMiddleware());
 app.use(cors());
-app.use(helmet());
 app.use(compression());
 app.use(express.json());
 app.use(rateLimit('student-service'));

--- a/packages/user-service/src/app.ts
+++ b/packages/user-service/src/app.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import cors from 'cors';
-import helmet from 'helmet';
 import compression from 'compression';
 import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
 
@@ -24,7 +23,6 @@ const monitoringService = MonitoringService.getInstance();
 app.use(securityHeaders);
 app.use(ipRateLimitMiddleware());
 app.use(cors());
-app.use(helmet());
 app.use(compression() as unknown as express.RequestHandler);
 app.use(express.json());
 app.use(rateLimit('user-service'));


### PR DESCRIPTION
## Summary
- remove `helmet` usage and keep `securityHeaders`
- ensure every service adds middleware in the same order
- apply CORS and compression to the API Gateway

## Testing
- `pnpm test` *(fails: Prisma generation only)*
- `pnpm lint` *(fails: missing ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6844860e5e9883338b155489d3ec3631