### PR TITLE
Switch to securityHeadersMiddleware

### DIFF
--- a/packages/admin-service/src/app.ts
+++ b/packages/admin-service/src/app.ts
@@ -1,42 +1,47 @@
-import express from 'express';
-import cors from 'cors';
-import helmet from 'helmet';
-import compression from 'compression';
-import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
-import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
-import { AdminController } from './api/controllers/admin.controller';
-import { createAdminRoutes } from './api/routes/admin.routes';
-import { MetricsService } from './services/metrics.service';
-import { ConfigService } from './services/config.service';
-import { ReportService } from './services/report.service';
-import { MonitoringService } from '@send/shared';
-import { logger } from '@shared/logger';
+import express from "express";
+import cors from "cors";
+import helmet from "helmet";
+import compression from "compression";
+import { rateLimit } from "@send/shared/security/middleware";
+import { securityHeadersMiddleware } from "@send/shared/security/headers";
+import { ipRateLimitMiddleware } from "@send/shared/security/ip-rate-limiter";
+import { AdminController } from "./api/controllers/admin.controller";
+import { createAdminRoutes } from "./api/routes/admin.routes";
+import { MetricsService } from "./services/metrics.service";
+import { ConfigService } from "./services/config.service";
+import { ReportService } from "./services/report.service";
+import { MonitoringService } from "@send/shared";
+import { logger } from "@shared/logger";
 
 const metricsService = new MetricsService();
 const configService = new ConfigService();
 const reportService = new ReportService(metricsService);
-const controller = new AdminController(metricsService, configService, reportService);
+const controller = new AdminController(
+  metricsService,
+  configService,
+  reportService,
+);
 
 const app = express();
-app.use(securityHeaders);
+app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
 app.use(cors());
 app.use(helmet());
 app.use(compression());
 app.use(express.json());
-app.use(rateLimit('admin-service'));
+app.use(rateLimit("admin-service"));
 
-app.use('/api', createAdminRoutes(controller));
+app.use("/api", createAdminRoutes(controller));
 
 const monitoringService = MonitoringService.getInstance();
-app.get('/metrics', async (_req, res) => {
+app.get("/metrics", async (_req, res) => {
   try {
     const metrics = await monitoringService.getMetrics();
-    res.set('Content-Type', 'text/plain');
+    res.set("Content-Type", "text/plain");
     res.send(metrics);
   } catch (error) {
-    logger.error('Failed to get metrics:', error);
-    res.status(500).send('Failed to get metrics');
+    logger.error("Failed to get metrics:", error);
+    res.status(500).send("Failed to get metrics");
   }
 });
 

--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -1,20 +1,21 @@
-import express from 'express';
-import { createProxyMiddleware } from 'http-proxy-middleware';
-import { authenticate } from '@send/shared';
-import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
-import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
-import { serviceConfig } from './config';
-import { LoggerService } from '@shared/logging/logger.service';
-import { CircuitBreakerService } from '@shared/circuit-breaker';
-import { MonitoringService } from '@send/shared';
+import express from "express";
+import { createProxyMiddleware } from "http-proxy-middleware";
+import { authenticate } from "@send/shared";
+import { rateLimit } from "@send/shared/security/middleware";
+import { securityHeadersMiddleware } from "@send/shared/security/headers";
+import { ipRateLimitMiddleware } from "@send/shared/security/ip-rate-limiter";
+import { serviceConfig } from "./config";
+import { LoggerService } from "@shared/logging/logger.service";
+import { CircuitBreakerService } from "@shared/circuit-breaker";
+import { MonitoringService } from "@send/shared";
 
 const logger = new LoggerService({
-  serviceName: 'api-gateway',
-  logLevel: process.env.LOG_LEVEL || 'info'
+  serviceName: "api-gateway",
+  logLevel: process.env.LOG_LEVEL || "info",
 });
 
-const retryAttempts = parseInt(process.env.PROXY_RETRY_ATTEMPTS || '3', 10);
-const retryDelay = parseInt(process.env.PROXY_RETRY_DELAY_MS || '100', 10);
+const retryAttempts = parseInt(process.env.PROXY_RETRY_ATTEMPTS || "3", 10);
+const retryDelay = parseInt(process.env.PROXY_RETRY_DELAY_MS || "100", 10);
 
 function createResilientProxy(target: string, serviceName: string) {
   const breaker = new CircuitBreakerService(serviceName);
@@ -23,29 +24,29 @@ function createResilientProxy(target: string, serviceName: string) {
   return async (
     req: express.Request,
     res: express.Response,
-    next: express.NextFunction
+    next: express.NextFunction,
   ) => {
     for (let attempt = 0; attempt < retryAttempts; attempt++) {
       try {
         await breaker.execute(
           () =>
             new Promise<void>((resolve, reject) => {
-              proxy(req, res, err => {
+              proxy(req, res, (err) => {
                 if (err) reject(err);
                 else resolve();
               });
-            })
+            }),
         );
         return;
       } catch (error) {
         logger.warn(`Proxy attempt ${attempt + 1} failed for ${serviceName}`, {
-          error
+          error,
         });
         if (attempt < retryAttempts - 1) {
-          await new Promise(resolve => setTimeout(resolve, retryDelay));
+          await new Promise((resolve) => setTimeout(resolve, retryDelay));
         } else {
           logger.error(`Proxy failed for ${serviceName}`, { error });
-          return res.status(502).json({ error: 'Bad gateway' });
+          return res.status(502).json({ error: "Bad gateway" });
         }
       }
     }
@@ -56,41 +57,71 @@ function createResilientProxy(target: string, serviceName: string) {
 const app = express();
 
 app.use(express.json());
-app.use(securityHeaders);
+app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
-app.use(rateLimit('api-gateway'));
+app.use(rateLimit("api-gateway"));
 
 // Request/response logging
 app.use((req, res, next) => {
-  res.on('finish', () => {
-    logger.info('Request handled', {
+  res.on("finish", () => {
+    logger.info("Request handled", {
       method: req.method,
       path: req.path,
       status: res.statusCode,
-      userId: (req as any).user?.id || null
+      userId: (req as any).user?.id || null,
     });
   });
   next();
 });
 
 // Apply authentication to all API routes
-app.use('/api', authenticate());
+app.use("/api", authenticate());
 
 // Proxy rules
 
-app.use('/api/auth', createResilientProxy(serviceConfig.userService, 'user-service'));
-app.use('/api/users', createResilientProxy(serviceConfig.userService, 'user-service'));
-app.use('/api/runs', createResilientProxy(serviceConfig.runService, 'run-service'));
-app.use('/api/students', createResilientProxy(serviceConfig.studentService, 'student-service'));
-app.use('/api/drivers', createResilientProxy(serviceConfig.driverService, 'driver-service'));
-app.use('/api/vehicles', createResilientProxy(serviceConfig.vehicleService, 'vehicle-service'));
-app.use('/api/documents', createResilientProxy(serviceConfig.documentService, 'document-service'));
-app.use('/api/incidents', createResilientProxy(serviceConfig.incidentService, 'incident-service'));
-app.use('/api/invoices', createResilientProxy(serviceConfig.invoicingService, 'invoicing-service'));
-app.use('/api/admin', createResilientProxy(serviceConfig.adminService, 'admin-service'));
+app.use(
+  "/api/auth",
+  createResilientProxy(serviceConfig.userService, "user-service"),
+);
+app.use(
+  "/api/users",
+  createResilientProxy(serviceConfig.userService, "user-service"),
+);
+app.use(
+  "/api/runs",
+  createResilientProxy(serviceConfig.runService, "run-service"),
+);
+app.use(
+  "/api/students",
+  createResilientProxy(serviceConfig.studentService, "student-service"),
+);
+app.use(
+  "/api/drivers",
+  createResilientProxy(serviceConfig.driverService, "driver-service"),
+);
+app.use(
+  "/api/vehicles",
+  createResilientProxy(serviceConfig.vehicleService, "vehicle-service"),
+);
+app.use(
+  "/api/documents",
+  createResilientProxy(serviceConfig.documentService, "document-service"),
+);
+app.use(
+  "/api/incidents",
+  createResilientProxy(serviceConfig.incidentService, "incident-service"),
+);
+app.use(
+  "/api/invoices",
+  createResilientProxy(serviceConfig.invoicingService, "invoicing-service"),
+);
+app.use(
+  "/api/admin",
+  createResilientProxy(serviceConfig.adminService, "admin-service"),
+);
 
 // Aggregate health check
-app.get('/health', async (_req, res) => {
+app.get("/health", async (_req, res) => {
   const services = {
     userService: serviceConfig.userService,
     runService: serviceConfig.runService,
@@ -100,7 +131,7 @@ app.get('/health', async (_req, res) => {
     documentService: serviceConfig.documentService,
     incidentService: serviceConfig.incidentService,
     invoicingService: serviceConfig.invoicingService,
-    adminService: serviceConfig.adminService
+    adminService: serviceConfig.adminService,
   } as const;
 
   const results: Record<string, any> = {};
@@ -108,27 +139,27 @@ app.get('/health', async (_req, res) => {
     Object.entries(services).map(async ([name, url]) => {
       try {
         const resp = await fetch(`${url}/health`, {
-          signal: AbortSignal.timeout(3000)
+          signal: AbortSignal.timeout(3000),
         });
         results[name] = await resp.json();
       } catch (err) {
-        results[name] = { status: 'DOWN' };
+        results[name] = { status: "DOWN" };
       }
-    })
+    }),
   );
 
   res.status(200).json(results);
 });
 
 const monitoringService = MonitoringService.getInstance();
-app.get('/metrics', async (_req, res) => {
+app.get("/metrics", async (_req, res) => {
   try {
     const metrics = await monitoringService.getMetrics();
-    res.set('Content-Type', 'text/plain');
+    res.set("Content-Type", "text/plain");
     res.send(metrics);
   } catch (error) {
-    logger.error('Failed to get metrics:', error);
-    res.status(500).send('Failed to get metrics');
+    logger.error("Failed to get metrics:", error);
+    res.status(500).send("Failed to get metrics");
   }
 });
 

--- a/packages/document-service/src/app.ts
+++ b/packages/document-service/src/app.ts
@@ -1,77 +1,83 @@
-import express from 'express';
-import cors from 'cors';
-import helmet from 'helmet';
-import compression from 'compression';
-import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
-import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
-import { databaseService } from '@send/shared';
-import { DocumentController } from './api/controllers/document.controller';
-import { DocumentService } from './services/document.service';
-import { HealthCheckService } from '@shared/health/health.check';
-import { RabbitMQService } from '@shared/messaging/rabbitmq.service';
-import { LoggerService } from '@shared/logging/logger.service';
-import { createDocumentRoutes } from './api/routes/document.routes';
-import { errorHandler, AppError } from '@shared/errors';
-import { createErrorResponse } from '@shared/responses';
-import { MonitoringService } from '@send/shared';
+import express from "express";
+import cors from "cors";
+import helmet from "helmet";
+import compression from "compression";
+import { rateLimit } from "@send/shared/security/middleware";
+import { securityHeadersMiddleware } from "@send/shared/security/headers";
+import { ipRateLimitMiddleware } from "@send/shared/security/ip-rate-limiter";
+import { databaseService } from "@send/shared";
+import { DocumentController } from "./api/controllers/document.controller";
+import { DocumentService } from "./services/document.service";
+import { HealthCheckService } from "@shared/health/health.check";
+import { RabbitMQService } from "@shared/messaging/rabbitmq.service";
+import { LoggerService } from "@shared/logging/logger.service";
+import { createDocumentRoutes } from "./api/routes/document.routes";
+import { errorHandler, AppError } from "@shared/errors";
+import { createErrorResponse } from "@shared/responses";
+import { MonitoringService } from "@send/shared";
 
 const app = express();
 const prisma = databaseService.getPrismaClient();
 
 // Initialize services
 const logger = new LoggerService({
-  serviceName: 'document-service',
-  logLevel: process.env.LOG_LEVEL || 'info',
-  logFile: process.env.LOG_FILE
+  serviceName: "document-service",
+  logLevel: process.env.LOG_LEVEL || "info",
+  logFile: process.env.LOG_FILE,
 });
 
 const rabbitMQ = new RabbitMQService(
   {
-    url: process.env.RABBITMQ_URL || 'amqp://localhost',
-    exchange: 'document-events',
-    queue: 'document-notifications'
+    url: process.env.RABBITMQ_URL || "amqp://localhost",
+    exchange: "document-events",
+    queue: "document-notifications",
   },
-  logger.getLogger()
+  logger.getLogger(),
 );
 
 const documentService = new DocumentService(prisma, rabbitMQ, logger);
 const documentController = new DocumentController(documentService);
-const healthCheckService = new HealthCheckService(prisma, rabbitMQ.getChannel(), logger.getLogger(), 'document-service');
+const healthCheckService = new HealthCheckService(
+  prisma,
+  rabbitMQ.getChannel(),
+  logger.getLogger(),
+  "document-service",
+);
 
 // Middleware
-app.use(securityHeaders);
+app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
 app.use(cors());
 app.use(helmet());
 app.use(compression());
 app.use(express.json());
-app.use(rateLimit('document-service'));
+app.use(rateLimit("document-service"));
 
 // Routes
-app.use('/api/documents', createDocumentRoutes(documentController));
+app.use("/api/documents", createDocumentRoutes(documentController));
 
 // Health check
-app.get('/health', async (req, res) => {
+app.get("/health", async (req, res) => {
   try {
     const health = await healthCheckService.checkHealth();
-    res.status(health.status === 'UP' ? 200 : 503).json(health);
+    res.status(health.status === "UP" ? 200 : 503).json(health);
   } catch (error) {
-    logger.error('Health check failed', { error });
-    res.status(503).json(
-      createErrorResponse(new AppError('Health check failed', 503))
-    );
+    logger.error("Health check failed", { error });
+    res
+      .status(503)
+      .json(createErrorResponse(new AppError("Health check failed", 503)));
   }
 });
 
 const monitoringService = MonitoringService.getInstance();
-app.get('/metrics', async (_req, res) => {
+app.get("/metrics", async (_req, res) => {
   try {
     const metrics = await monitoringService.getMetrics();
-    res.set('Content-Type', 'text/plain');
+    res.set("Content-Type", "text/plain");
     res.send(metrics);
   } catch (error) {
-    logger.error('Failed to get metrics', { error });
-    res.status(500).send('Failed to get metrics');
+    logger.error("Failed to get metrics", { error });
+    res.status(500).send("Failed to get metrics");
   }
 });
 

--- a/packages/driver-service/src/index.ts
+++ b/packages/driver-service/src/index.ts
@@ -1,51 +1,61 @@
-import express from 'express';
-import { databaseService, LoggerService, HealthCheckService } from '@send/shared';
-import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
-import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
-import cors from 'cors';
-import helmet from 'helmet';
-import compression from 'compression';
-import { RabbitMQService } from './infra/messaging/rabbitmq';
-import { DriverService } from './infra/services/driver.service';
-import { DriverController } from './api/controllers/driver.controller';
-import { createDriverRoutes } from './api/routes/driver.routes';
-import { MonitoringService } from '@send/shared';
+import express from "express";
+import {
+  databaseService,
+  LoggerService,
+  HealthCheckService,
+} from "@send/shared";
+import { rateLimit } from "@send/shared/security/middleware";
+import { securityHeadersMiddleware } from "@send/shared/security/headers";
+import { ipRateLimitMiddleware } from "@send/shared/security/ip-rate-limiter";
+import cors from "cors";
+import helmet from "helmet";
+import compression from "compression";
+import { RabbitMQService } from "./infra/messaging/rabbitmq";
+import { DriverService } from "./infra/services/driver.service";
+import { DriverController } from "./api/controllers/driver.controller";
+import { createDriverRoutes } from "./api/routes/driver.routes";
+import { MonitoringService } from "@send/shared";
 
 const app = express();
 const prisma = databaseService.getPrismaClient();
 const rabbitMQ = new RabbitMQService();
-const logger = new LoggerService({ serviceName: 'driver-service' });
-const healthCheck = new HealthCheckService(prisma, rabbitMQ.getChannel(), logger.getLogger(), 'driver-service');
+const logger = new LoggerService({ serviceName: "driver-service" });
+const healthCheck = new HealthCheckService(
+  prisma,
+  rabbitMQ.getChannel(),
+  logger.getLogger(),
+  "driver-service",
+);
 
 const driverService = new DriverService(prisma, rabbitMQ);
 const driverController = new DriverController(driverService);
 
 // Middleware
-app.use(securityHeaders);
+app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
 app.use(cors());
 app.use(helmet());
 app.use(compression());
 app.use(express.json());
-app.use(rateLimit('driver-service'));
+app.use(rateLimit("driver-service"));
 
 // Set up routes
-app.use('/api', createDriverRoutes(driverController));
+app.use("/api", createDriverRoutes(driverController));
 
-app.get('/health', async (_req, res) => {
+app.get("/health", async (_req, res) => {
   const health = await healthCheck.checkHealth();
-  res.status(health.status === 'UP' ? 200 : 503).json(health);
+  res.status(health.status === "UP" ? 200 : 503).json(health);
 });
 
 const monitoringService = MonitoringService.getInstance();
-app.get('/metrics', async (_req, res) => {
+app.get("/metrics", async (_req, res) => {
   try {
     const metrics = await monitoringService.getMetrics();
-    res.set('Content-Type', 'text/plain');
+    res.set("Content-Type", "text/plain");
     res.send(metrics);
   } catch (error) {
-    logger.error('Failed to get metrics:', error);
-    res.status(500).send('Failed to get metrics');
+    logger.error("Failed to get metrics:", error);
+    res.status(500).send("Failed to get metrics");
   }
 });
 
@@ -54,7 +64,7 @@ async function start() {
   try {
     await rabbitMQ.connect();
     await rabbitMQ.subscribeToDriverEvents(async (event) => {
-      logger.info('Received driver event:', event);
+      logger.info("Received driver event:", event);
       // Handle driver events as needed
     });
 
@@ -63,7 +73,7 @@ async function start() {
       logger.info(`Driver service listening on port ${port}`);
     });
   } catch (error) {
-    logger.error('Failed to start driver service:', error);
+    logger.error("Failed to start driver service:", error);
     process.exit(1);
   }
 }
@@ -71,11 +81,11 @@ async function start() {
 start();
 
 async function shutdown() {
-  logger.info('Shutting down gracefully...');
+  logger.info("Shutting down gracefully...");
   await rabbitMQ.close();
   await prisma.$disconnect();
   process.exit(0);
 }
 
-process.on('SIGTERM', shutdown);
-process.on('SIGINT', shutdown);
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/packages/incident-service/src/app.ts
+++ b/packages/incident-service/src/app.ts
@@ -1,61 +1,71 @@
-import express from 'express';
-import cors from 'cors';
-import helmet from 'helmet';
-import compression from 'compression';
-import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
-import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
-import { databaseService, LoggerService, HealthCheckService } from '@send/shared';
-import { IncidentService } from './services/incident.service';
-import { IncidentController } from './api/controllers/incident.controller';
-import { createIncidentRoutes } from './api/routes/incident.routes';
-import { RabbitMQService } from '@shared/messaging/rabbitmq.service';
-import { startEscalationJob } from './jobs/escalation.job';
-import { MonitoringService } from '@send/shared';
+import express from "express";
+import cors from "cors";
+import helmet from "helmet";
+import compression from "compression";
+import { rateLimit } from "@send/shared/security/middleware";
+import { securityHeadersMiddleware } from "@send/shared/security/headers";
+import { ipRateLimitMiddleware } from "@send/shared/security/ip-rate-limiter";
+import {
+  databaseService,
+  LoggerService,
+  HealthCheckService,
+} from "@send/shared";
+import { IncidentService } from "./services/incident.service";
+import { IncidentController } from "./api/controllers/incident.controller";
+import { createIncidentRoutes } from "./api/routes/incident.routes";
+import { RabbitMQService } from "@shared/messaging/rabbitmq.service";
+import { startEscalationJob } from "./jobs/escalation.job";
+import { MonitoringService } from "@send/shared";
 
 export const prisma = databaseService.getPrismaClient();
 export const logger = new LoggerService({
-  serviceName: 'incident-service',
-  logLevel: process.env.LOG_LEVEL || 'info'
+  serviceName: "incident-service",
+  logLevel: process.env.LOG_LEVEL || "info",
 });
 export const rabbitMQ = new RabbitMQService(
   {
-    url: process.env.RABBITMQ_URL || 'amqp://localhost',
-    exchange: 'incident-events',
-    queue: 'incident-notifications'
+    url: process.env.RABBITMQ_URL || "amqp://localhost",
+    exchange: "incident-events",
+    queue: "incident-notifications",
   },
-  logger.getLogger()
+  logger.getLogger(),
 );
 
-const healthCheck = new HealthCheckService(prisma, rabbitMQ.getChannel(), logger.getLogger(), 'incident-service');
+const healthCheck = new HealthCheckService(
+  prisma,
+  rabbitMQ.getChannel(),
+  logger.getLogger(),
+  "incident-service",
+);
 
 export const incidentService = new IncidentService(prisma);
 const incidentController = new IncidentController(incidentService);
 
 const app = express();
-app.use(securityHeaders);
+app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
 app.use(cors());
 app.use(helmet());
 app.use(compression());
 app.use(express.json());
-app.use(rateLimit('incident-service'));
+app.use(rateLimit("incident-service"));
 
-app.use('/api/incidents', createIncidentRoutes(incidentController));
+app.use("/api/incidents", createIncidentRoutes(incidentController));
 
-app.get('/health', async (_req, res) => {
+app.get("/health", async (_req, res) => {
   const health = await healthCheck.checkHealth();
-  res.status(health.status === 'UP' ? 200 : 503).json(health);
+  res.status(health.status === "UP" ? 200 : 503).json(health);
 });
 
 const monitoringService = MonitoringService.getInstance();
-app.get('/metrics', async (_req, res) => {
+app.get("/metrics", async (_req, res) => {
   try {
     const metrics = await monitoringService.getMetrics();
-    res.set('Content-Type', 'text/plain');
+    res.set("Content-Type", "text/plain");
     res.send(metrics);
   } catch (error) {
-    logger.error('Failed to get metrics', { error });
-    res.status(500).send('Failed to get metrics');
+    logger.error("Failed to get metrics", { error });
+    res.status(500).send("Failed to get metrics");
   }
 });
 

--- a/packages/invoicing-service/src/app.ts
+++ b/packages/invoicing-service/src/app.ts
@@ -1,46 +1,56 @@
-import express from 'express';
-import cors from 'cors';
-import helmet from 'helmet';
-import compression from 'compression';
-import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
-import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
-import { databaseService, LoggerService, HealthCheckService } from '@send/shared';
-import { InvoiceService } from './services/invoice.service';
-import { InvoiceController } from './api/controllers/invoice.controller';
-import { createInvoiceRoutes } from './api/routes/invoice.routes';
-import { MonitoringService } from '@send/shared';
-const logger = new LoggerService({ serviceName: 'invoicing-service' });
+import express from "express";
+import cors from "cors";
+import helmet from "helmet";
+import compression from "compression";
+import { rateLimit } from "@send/shared/security/middleware";
+import { securityHeadersMiddleware } from "@send/shared/security/headers";
+import { ipRateLimitMiddleware } from "@send/shared/security/ip-rate-limiter";
+import {
+  databaseService,
+  LoggerService,
+  HealthCheckService,
+} from "@send/shared";
+import { InvoiceService } from "./services/invoice.service";
+import { InvoiceController } from "./api/controllers/invoice.controller";
+import { createInvoiceRoutes } from "./api/routes/invoice.routes";
+import { MonitoringService } from "@send/shared";
+const logger = new LoggerService({ serviceName: "invoicing-service" });
 
 const prisma = databaseService.getPrismaClient();
-const healthCheck = new HealthCheckService(prisma, null, logger.getLogger(), 'invoicing-service');
+const healthCheck = new HealthCheckService(
+  prisma,
+  null,
+  logger.getLogger(),
+  "invoicing-service",
+);
 export const invoiceService = new InvoiceService(prisma);
 const invoiceController = new InvoiceController(invoiceService);
 
 const app = express();
-app.use(securityHeaders);
+app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
 app.use(cors());
 app.use(helmet());
 app.use(compression());
 app.use(express.json());
-app.use(rateLimit('invoicing-service'));
+app.use(rateLimit("invoicing-service"));
 
-app.use('/api/invoices', createInvoiceRoutes(invoiceController));
+app.use("/api/invoices", createInvoiceRoutes(invoiceController));
 
-app.get('/health', async (_req, res) => {
+app.get("/health", async (_req, res) => {
   const health = await healthCheck.checkHealth();
-  res.status(health.status === 'UP' ? 200 : 503).json(health);
+  res.status(health.status === "UP" ? 200 : 503).json(health);
 });
 
 const monitoringService = MonitoringService.getInstance();
-app.get('/metrics', async (_req, res) => {
+app.get("/metrics", async (_req, res) => {
   try {
     const metrics = await monitoringService.getMetrics();
-    res.set('Content-Type', 'text/plain');
+    res.set("Content-Type", "text/plain");
     res.send(metrics);
   } catch (error) {
-    logger.error('Failed to get metrics:', error);
-    res.status(500).send('Failed to get metrics');
+    logger.error("Failed to get metrics:", error);
+    res.status(500).send("Failed to get metrics");
   }
 });
 

--- a/packages/run-service/src/app.ts
+++ b/packages/run-service/src/app.ts
@@ -1,25 +1,35 @@
-import express, { ErrorRequestHandler } from 'express';
-import cors from 'cors';
-import helmet from 'helmet';
-import compression from 'compression';
-import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
-import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
-import { databaseService, LoggerService, HealthCheckService } from '@send/shared';
-import { RunModel } from './data/models/run.model';
-import { RunController } from './api/controllers/run.controller';
-import { RabbitMQService } from './infra/messaging/rabbitmq';
-import { RouteService } from './infra/services/route.service';
-import { ScheduleService } from './infra/services/schedule.service';
-import { createRunRoutes } from './api/routes/run.routes';
-import { errorHandler } from '@shared/errors';
-import { MonitoringService } from '@send/shared';
-const logger = new LoggerService({ serviceName: 'run-service' });
+import express, { ErrorRequestHandler } from "express";
+import cors from "cors";
+import helmet from "helmet";
+import compression from "compression";
+import { rateLimit } from "@send/shared/security/middleware";
+import { securityHeadersMiddleware } from "@send/shared/security/headers";
+import { ipRateLimitMiddleware } from "@send/shared/security/ip-rate-limiter";
+import {
+  databaseService,
+  LoggerService,
+  HealthCheckService,
+} from "@send/shared";
+import { RunModel } from "./data/models/run.model";
+import { RunController } from "./api/controllers/run.controller";
+import { RabbitMQService } from "./infra/messaging/rabbitmq";
+import { RouteService } from "./infra/services/route.service";
+import { ScheduleService } from "./infra/services/schedule.service";
+import { createRunRoutes } from "./api/routes/run.routes";
+import { errorHandler } from "@shared/errors";
+import { MonitoringService } from "@send/shared";
+const logger = new LoggerService({ serviceName: "run-service" });
 
 const app = express();
 const prisma = databaseService.getPrismaClient();
 const runModel = new RunModel(prisma);
 const rabbitMQ = new RabbitMQService();
-const healthCheck = new HealthCheckService(prisma, rabbitMQ.getChannel(), logger.getLogger(), 'run-service');
+const healthCheck = new HealthCheckService(
+  prisma,
+  rabbitMQ.getChannel(),
+  logger.getLogger(),
+  "run-service",
+);
 const routeService = new RouteService();
 const scheduleService = new ScheduleService();
 
@@ -27,43 +37,43 @@ const scheduleService = new ScheduleService();
 rabbitMQ.connect().catch(console.error);
 
 // Middleware
-app.use(securityHeaders);
+app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
 app.use(cors());
 app.use(helmet());
 app.use(compression());
 app.use(express.json());
-app.use(rateLimit('run-service'));
+app.use(rateLimit("run-service"));
 
 // Initialize controller with all services
 const runController = new RunController(
   runModel,
   rabbitMQ,
   routeService,
-  scheduleService
+  scheduleService,
 );
 
 // Routes
-app.use('/api/runs', createRunRoutes(runController));
+app.use("/api/runs", createRunRoutes(runController));
 
-app.get('/health', async (_req, res) => {
+app.get("/health", async (_req, res) => {
   const health = await healthCheck.checkHealth();
-  res.status(health.status === 'UP' ? 200 : 503).json(health);
+  res.status(health.status === "UP" ? 200 : 503).json(health);
 });
 
 const monitoringService = MonitoringService.getInstance();
-app.get('/metrics', async (_req, res) => {
+app.get("/metrics", async (_req, res) => {
   try {
     const metrics = await monitoringService.getMetrics();
-    res.set('Content-Type', 'text/plain');
+    res.set("Content-Type", "text/plain");
     res.send(metrics);
   } catch (error) {
-    logger.error('Failed to get metrics:', error);
-    res.status(500).send('Failed to get metrics');
+    logger.error("Failed to get metrics:", error);
+    res.status(500).send("Failed to get metrics");
   }
 });
 
 // Error handling middleware
 app.use(errorHandler as ErrorRequestHandler);
 
-export default app; 
+export default app;

--- a/packages/student-service/src/app.ts
+++ b/packages/student-service/src/app.ts
@@ -1,41 +1,42 @@
-import express from 'express';
-import cors from 'cors';
-import helmet from 'helmet';
-import compression from 'compression';
-import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
-import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
-import studentRoutes from './api/routes/student.routes';
-import { errorHandler } from '@shared/errors';
-import { MonitoringService } from '@send/shared';
-import { logger } from '@shared/logger';
+import express from "express";
+import cors from "cors";
+import helmet from "helmet";
+import compression from "compression";
+import { rateLimit } from "@send/shared/security/middleware";
+import { securityHeadersMiddleware } from "@send/shared/security/headers";
+import { ipRateLimitMiddleware } from "@send/shared/security/ip-rate-limiter";
+import studentRoutes from "./api/routes/student.routes";
+import { errorHandler } from "@shared/errors";
+import { MonitoringService } from "@send/shared";
+import { logger } from "@shared/logger";
 
 const app = express();
 
 // Middleware
-app.use(securityHeaders);
+app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
 app.use(cors());
 app.use(helmet());
 app.use(compression());
 app.use(express.json());
-app.use(rateLimit('student-service'));
+app.use(rateLimit("student-service"));
 
 // Routes
-app.use('/api/students', studentRoutes);
+app.use("/api/students", studentRoutes);
 
 const monitoringService = MonitoringService.getInstance();
-app.get('/metrics', async (_req, res) => {
+app.get("/metrics", async (_req, res) => {
   try {
     const metrics = await monitoringService.getMetrics();
-    res.set('Content-Type', 'text/plain');
+    res.set("Content-Type", "text/plain");
     res.send(metrics);
   } catch (error) {
-    logger.error('Failed to get metrics:', error);
-    res.status(500).send('Failed to get metrics');
+    logger.error("Failed to get metrics:", error);
+    res.status(500).send("Failed to get metrics");
   }
 });
 
 // Error handling middleware
 app.use(errorHandler);
 
-export default app; 
+export default app;

--- a/packages/tracking-service/src/index.ts
+++ b/packages/tracking-service/src/index.ts
@@ -1,107 +1,117 @@
-import 'dotenv/config';
-import express from 'express';
-import { Server } from 'socket.io';
-import { createServer } from 'http';
-import cors from 'cors';
-import helmet from 'helmet';
-import compression from 'compression';
-import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
-import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
-import { databaseService, LoggerService, HealthCheckService } from '@send/shared';
-import { RabbitMQService } from './infra/messaging/rabbitmq';
-import { TrackingService } from './infra/services/tracking.service';
-import { TrackingController } from './api/controllers/tracking.controller';
-import { createTrackingRoutes } from './api/routes/tracking.routes';
-import { Geofence } from '@shared/types/tracking';
-import { MonitoringService } from '@send/shared';
+import "dotenv/config";
+import express from "express";
+import { Server } from "socket.io";
+import { createServer } from "http";
+import cors from "cors";
+import helmet from "helmet";
+import compression from "compression";
+import { rateLimit } from "@send/shared/security/middleware";
+import { securityHeadersMiddleware } from "@send/shared/security/headers";
+import { ipRateLimitMiddleware } from "@send/shared/security/ip-rate-limiter";
+import {
+  databaseService,
+  LoggerService,
+  HealthCheckService,
+} from "@send/shared";
+import { RabbitMQService } from "./infra/messaging/rabbitmq";
+import { TrackingService } from "./infra/services/tracking.service";
+import { TrackingController } from "./api/controllers/tracking.controller";
+import { createTrackingRoutes } from "./api/routes/tracking.routes";
+import { Geofence } from "@shared/types/tracking";
+import { MonitoringService } from "@send/shared";
 
 const app = express();
 const httpServer = createServer(app);
 const io = new Server(httpServer, {
   cors: {
-    origin: '*',
-    methods: ['GET', 'POST']
-  }
+    origin: "*",
+    methods: ["GET", "POST"],
+  },
 });
 
 const prisma = databaseService.getPrismaClient();
 const rabbitMQ = new RabbitMQService();
-const logger = new LoggerService({ serviceName: 'tracking-service' });
-const healthCheck = new HealthCheckService(prisma, rabbitMQ.getChannel(), logger.getLogger(), 'tracking-service');
+const logger = new LoggerService({ serviceName: "tracking-service" });
+const healthCheck = new HealthCheckService(
+  prisma,
+  rabbitMQ.getChannel(),
+  logger.getLogger(),
+  "tracking-service",
+);
 
 // Define geofences for pickup and dropoff locations
 const geofences: Geofence[] = [
   {
-    id: 'pickup-zone',
-    name: 'Pickup Zone',
-    type: 'PICKUP',
+    id: "pickup-zone",
+    name: "Pickup Zone",
+    type: "PICKUP",
     center: {
       latitude: 51.5074,
       longitude: -0.1278,
-      timestamp: new Date()
+      timestamp: new Date(),
     },
-    radius: 100 // meters
+    radius: 100, // meters
   },
   {
-    id: 'dropoff-zone',
-    name: 'Dropoff Zone',
-    type: 'DROPOFF',
+    id: "dropoff-zone",
+    name: "Dropoff Zone",
+    type: "DROPOFF",
     center: {
       latitude: 51.5074,
       longitude: -0.1278,
-      timestamp: new Date()
+      timestamp: new Date(),
     },
-    radius: 100 // meters
-  }
+    radius: 100, // meters
+  },
 ];
 
 const trackingService = new TrackingService(prisma, rabbitMQ, geofences);
 const trackingController = new TrackingController(trackingService);
 
 // Middleware
-app.use(securityHeaders);
+app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
 app.use(cors());
 app.use(helmet());
 app.use(compression());
 app.use(express.json());
-app.use(rateLimit('tracking-service'));
+app.use(rateLimit("tracking-service"));
 
 // Set up routes
-app.use('/api', createTrackingRoutes(trackingController));
+app.use("/api", createTrackingRoutes(trackingController));
 
-app.get('/health', async (_req, res) => {
+app.get("/health", async (_req, res) => {
   const health = await healthCheck.checkHealth();
-  res.status(health.status === 'UP' ? 200 : 503).json(health);
+  res.status(health.status === "UP" ? 200 : 503).json(health);
 });
 
 const monitoringService = MonitoringService.getInstance();
-app.get('/metrics', async (_req, res) => {
+app.get("/metrics", async (_req, res) => {
   try {
     const metrics = await monitoringService.getMetrics();
-    res.set('Content-Type', 'text/plain');
+    res.set("Content-Type", "text/plain");
     res.send(metrics);
   } catch (error) {
-    logger.error('Failed to get metrics:', error);
-    res.status(500).send('Failed to get metrics');
+    logger.error("Failed to get metrics:", error);
+    res.status(500).send("Failed to get metrics");
   }
 });
 
 // Set up WebSocket connections
-io.on('connection', (socket) => {
-  logger.info('Client connected');
+io.on("connection", (socket) => {
+  logger.info("Client connected");
 
-  socket.on('join-run', (runId: string) => {
+  socket.on("join-run", (runId: string) => {
     trackingService.addClient(runId, socket);
     logger.info(`Client joined run ${runId}`);
   });
 
-  socket.on('disconnect', () => {
+  socket.on("disconnect", () => {
     // Find and remove the socket from all runs
-    for (const [runId, tracking] of trackingService['activeRuns']) {
+    for (const [runId, tracking] of trackingService["activeRuns"]) {
       tracking.sockets.delete(socket);
     }
-    logger.info('Client disconnected');
+    logger.info("Client disconnected");
   });
 });
 
@@ -110,7 +120,7 @@ async function start() {
   try {
     await rabbitMQ.connect();
     await rabbitMQ.subscribeToTrackingEvents(async (event) => {
-      logger.info('Received tracking event:', event);
+      logger.info("Received tracking event:", event);
       // Handle tracking events as needed
     });
 
@@ -119,7 +129,7 @@ async function start() {
       logger.info(`Tracking service listening on port ${port}`);
     });
   } catch (error) {
-    logger.error('Failed to start tracking service:', error);
+    logger.error("Failed to start tracking service:", error);
     process.exit(1);
   }
 }
@@ -127,14 +137,14 @@ async function start() {
 start();
 
 async function shutdown() {
-  logger.info('Shutting down gracefully...');
+  logger.info("Shutting down gracefully...");
   await rabbitMQ.close();
   await prisma.$disconnect();
   httpServer.close(() => {
-    logger.info('HTTP server closed');
+    logger.info("HTTP server closed");
     process.exit(0);
   });
 }
 
-process.on('SIGTERM', shutdown);
-process.on('SIGINT', shutdown);
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/packages/user-service/src/app.ts
+++ b/packages/user-service/src/app.ts
@@ -1,59 +1,63 @@
-import express from 'express';
-import cors from 'cors';
-import helmet from 'helmet';
-import compression from 'compression';
-import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
+import express from "express";
+import cors from "cors";
+import helmet from "helmet";
+import compression from "compression";
+import { rateLimit } from "@send/shared/security/middleware";
+import { securityHeadersMiddleware } from "@send/shared/security/headers";
 
-import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
+import { ipRateLimitMiddleware } from "@send/shared/security/ip-rate-limiter";
 
-import promBundle from 'express-prom-bundle';
-import { MonitoringService } from './infra/monitoring/monitoring.service';
-import { LoggerService } from '@send/shared';
+import promBundle from "express-prom-bundle";
+import { MonitoringService } from "./infra/monitoring/monitoring.service";
+import { LoggerService } from "@send/shared";
 
-
-import userRoutes from './api/routes/user.routes';
-import { errorHandler } from '@shared/errors';
+import userRoutes from "./api/routes/user.routes";
+import { errorHandler } from "@shared/errors";
 
 const app: express.Application = express();
-const logger = new LoggerService({ serviceName: 'user-service' });
+const logger = new LoggerService({ serviceName: "user-service" });
 
 // Initialize monitoring
 const monitoringService = MonitoringService.getInstance();
 
 // Middleware
-app.use(securityHeaders);
+app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
 app.use(cors());
 app.use(helmet());
 app.use(compression() as unknown as express.RequestHandler);
 app.use(express.json());
-app.use(rateLimit('user-service'));
+app.use(rateLimit("user-service"));
 app.use((req, res, next) => {
-  logger.info('Incoming request', { method: req.method, url: req.url, ip: req.ip });
+  logger.info("Incoming request", {
+    method: req.method,
+    url: req.url,
+    ip: req.ip,
+  });
   next();
 });
 
 // Routes
-app.use('/api/users', userRoutes);
+app.use("/api/users", userRoutes);
 
 // Health check
-app.get('/health', (req, res) => {
-  res.status(200).json({ status: 'healthy' });
+app.get("/health", (req, res) => {
+  res.status(200).json({ status: "healthy" });
 });
 
 // Metrics endpoint
-app.get('/metrics', async (req, res) => {
-    try {
-        const metrics = await monitoringService.getMetrics();
-        res.set('Content-Type', 'text/plain');
-        res.send(metrics);
-    } catch (error) {
-        logger.error('Failed to get metrics:', error);
-        res.status(500).send('Failed to get metrics');
-    }
+app.get("/metrics", async (req, res) => {
+  try {
+    const metrics = await monitoringService.getMetrics();
+    res.set("Content-Type", "text/plain");
+    res.send(metrics);
+  } catch (error) {
+    logger.error("Failed to get metrics:", error);
+    res.status(500).send("Failed to get metrics");
+  }
 });
 
 // Error handling
 app.use(errorHandler);
 
-export default app; 
+export default app;

--- a/packages/vehicle-service/src/index.ts
+++ b/packages/vehicle-service/src/index.ts
@@ -1,54 +1,64 @@
-import express from 'express';
-import { Server } from 'http';
-import { databaseService, LoggerService, HealthCheckService } from '@send/shared';
-import cors from 'cors';
-import helmet from 'helmet';
-import compression from 'compression';
-import { securityHeaders, rateLimit } from '@send/shared/security/middleware';
-import { ipRateLimitMiddleware } from '@send/shared/security/ip-rate-limiter';
-import { VehicleService } from './services/vehicle.service';
-import { VehicleController } from './api/controllers/vehicle.controller';
-import { createVehicleRoutes } from './api/routes/vehicle.routes';
-import { RabbitMQService } from './infra/messaging/rabbitmq';
+import express from "express";
+import { Server } from "http";
+import {
+  databaseService,
+  LoggerService,
+  HealthCheckService,
+} from "@send/shared";
+import cors from "cors";
+import helmet from "helmet";
+import compression from "compression";
+import { rateLimit } from "@send/shared/security/middleware";
+import { securityHeadersMiddleware } from "@send/shared/security/headers";
+import { ipRateLimitMiddleware } from "@send/shared/security/ip-rate-limiter";
+import { VehicleService } from "./services/vehicle.service";
+import { VehicleController } from "./api/controllers/vehicle.controller";
+import { createVehicleRoutes } from "./api/routes/vehicle.routes";
+import { RabbitMQService } from "./infra/messaging/rabbitmq";
 
-import { MonitoringService } from '@send/shared';
+import { MonitoringService } from "@send/shared";
 
 const app = express();
 const server = new Server(app);
 const prisma = databaseService.getPrismaClient();
 const { rabbitMQUrl, port } = getServiceConfig();
 const rabbitMQService = new RabbitMQService(rabbitMQUrl);
-const logger = new LoggerService({ serviceName: 'vehicle-service' });
-const healthCheck = new HealthCheckService(prisma, rabbitMQService.getChannel(), logger.getLogger(), 'vehicle-service');
+const logger = new LoggerService({ serviceName: "vehicle-service" });
+const healthCheck = new HealthCheckService(
+  prisma,
+  rabbitMQService.getChannel(),
+  logger.getLogger(),
+  "vehicle-service",
+);
 
 // Create services and controllers
 const vehicleService = new VehicleService(rabbitMQService);
 const vehicleController = new VehicleController(vehicleService);
 
 // Middleware
-app.use(securityHeaders);
+app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
 app.use(cors());
 app.use(helmet());
 app.use(compression());
 app.use(express.json());
-app.use(rateLimit('vehicle-service'));
-app.use('/api', createVehicleRoutes(vehicleController));
+app.use(rateLimit("vehicle-service"));
+app.use("/api", createVehicleRoutes(vehicleController));
 
-app.get('/health', async (_req, res) => {
+app.get("/health", async (_req, res) => {
   const health = await healthCheck.checkHealth();
-  res.status(health.status === 'UP' ? 200 : 503).json(health);
+  res.status(health.status === "UP" ? 200 : 503).json(health);
 });
 
 const monitoringService = MonitoringService.getInstance();
-app.get('/metrics', async (_req, res) => {
+app.get("/metrics", async (_req, res) => {
   try {
     const metrics = await monitoringService.getMetrics();
-    res.set('Content-Type', 'text/plain');
+    res.set("Content-Type", "text/plain");
     res.send(metrics);
   } catch (error) {
-    logger.error('Failed to get metrics:', error);
-    res.status(500).send('Failed to get metrics');
+    logger.error("Failed to get metrics:", error);
+    res.status(500).send("Failed to get metrics");
   }
 });
 
@@ -60,7 +70,7 @@ async function start() {
       logger.info(`Vehicle service listening on port ${port}`);
     });
   } catch (error) {
-    logger.error('Failed to start vehicle service:', error);
+    logger.error("Failed to start vehicle service:", error);
     process.exit(1);
   }
 }
@@ -68,11 +78,11 @@ async function start() {
 start();
 
 async function shutdown() {
-  logger.info('Shutting down gracefully...');
+  logger.info("Shutting down gracefully...");
   await rabbitMQService.close();
   await prisma.$disconnect();
   process.exit(0);
 }
 
-process.on('SIGTERM', shutdown);
-process.on('SIGINT', shutdown);
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);


### PR DESCRIPTION
## Summary
- replace use of `securityHeaders` middleware with new `securityHeadersMiddleware`
- update imports across all services

## Testing
- `npm run lint` *(fails: tasks not run)*
- `npm test` *(fails: running target test failed)*

------
https://chatgpt.com/codex/tasks/task_e_6844861556308333a0078cbfc6a52649