### PR TITLE
Standardize error responses

### DIFF
--- a/packages/invoicing-service/src/__tests__/controllers/invoice.controller.test.ts
+++ b/packages/invoicing-service/src/__tests__/controllers/invoice.controller.test.ts
@@ -43,6 +43,9 @@ describe('InvoiceController', () => {
     const res = await request(app).get('/invoices/1');
 
     expect(res.status).toBe(404);
-    expect(res.body).toEqual({ error: 'Invoice not found' });
+    expect(res.body).toEqual({
+      success: false,
+      error: { code: 'AppError', message: 'Invoice not found' }
+    });
   });
 });

--- a/packages/invoicing-service/src/api/controllers/invoice.controller.ts
+++ b/packages/invoicing-service/src/api/controllers/invoice.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { InvoiceService } from '../../services/invoice.service';
 import { InvoiceStatus } from '@shared/types/invoice';
+import { createErrorResponse, AppError } from '@send/shared';
 
 export class InvoiceController {
   constructor(private readonly invoiceService: InvoiceService) {}
@@ -10,7 +11,9 @@ export class InvoiceController {
       const invoice = await this.invoiceService.createInvoice(req.body);
       res.status(201).json(invoice);
     } catch (err) {
-      res.status(500).json({ error: 'Failed to create invoice' });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Failed to create invoice', 500)));
     }
   }
 
@@ -21,7 +24,9 @@ export class InvoiceController {
   async getById(req: Request, res: Response): Promise<void> {
     const invoice = await this.invoiceService.getInvoice(req.params.id);
     if (!invoice) {
-      res.status(404).json({ error: 'Invoice not found' });
+      res
+        .status(404)
+        .json(createErrorResponse(new AppError('Invoice not found', 404)));
       return;
     }
     res.json(invoice);
@@ -33,7 +38,9 @@ export class InvoiceController {
       req.body.status as InvoiceStatus
     );
     if (!invoice) {
-      res.status(404).json({ error: 'Invoice not found' });
+      res
+        .status(404)
+        .json(createErrorResponse(new AppError('Invoice not found', 404)));
       return;
     }
     res.json(invoice);
@@ -42,7 +49,9 @@ export class InvoiceController {
   async send(req: Request, res: Response): Promise<void> {
     const invoice = await this.invoiceService.sendInvoiceToSage(req.params.id);
     if (!invoice) {
-      res.status(404).json({ error: 'Invoice not found' });
+      res
+        .status(404)
+        .json(createErrorResponse(new AppError('Invoice not found', 404)));
       return;
     }
     res.json(invoice);

--- a/packages/student-service/src/__tests__/controllers/student.controller.test.ts
+++ b/packages/student-service/src/__tests__/controllers/student.controller.test.ts
@@ -91,7 +91,10 @@ describe('StudentController', () => {
       await studentController.createStudent(req as Request, res as Response);
 
       expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Failed to create student' });
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: { code: 'AppError', message: 'Failed to create student' }
+      });
     });
   });
 
@@ -125,7 +128,10 @@ describe('StudentController', () => {
       await studentController.getStudent(req as Request, res as Response);
 
       expect(res.status).toHaveBeenCalledWith(404);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Student not found' });
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: { code: 'AppError', message: 'Student not found' }
+      });
     });
 
     it('should return 500 on error', async () => {
@@ -135,7 +141,10 @@ describe('StudentController', () => {
       await studentController.getStudent(req as Request, res as Response);
 
       expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Failed to get student' });
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: { code: 'AppError', message: 'Failed to get student' }
+      });
     });
   });
 
@@ -193,7 +202,10 @@ describe('StudentController', () => {
       await studentController.getStudents(req as Request, res as Response);
 
       expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Failed to get students' });
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: { code: 'AppError', message: 'Failed to get students' }
+      });
     });
   });
 
@@ -226,7 +238,10 @@ describe('StudentController', () => {
       await studentController.addGuardian(req as Request, res as Response);
 
       expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Failed to add guardian' });
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: { code: 'AppError', message: 'Failed to add guardian' }
+      });
     });
   });
 
@@ -250,7 +265,10 @@ describe('StudentController', () => {
       await studentController.removeGuardian(req as Request, res as Response);
 
       expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Failed to remove guardian' });
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: { code: 'AppError', message: 'Failed to remove guardian' }
+      });
     });
   });
 
@@ -283,7 +301,10 @@ describe('StudentController', () => {
       await studentController.recordAttendance(req as Request, res as Response);
 
       expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Failed to record attendance' });
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: { code: 'AppError', message: 'Failed to record attendance' }
+      });
     });
   });
 }); 

--- a/packages/student-service/src/controllers/student.controller.ts
+++ b/packages/student-service/src/controllers/student.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { StudentModel } from '../data/models/student.model';
 import { Student, StudentCreateInput, StudentUpdateInput, StudentWhereInput } from '@shared/types/student';
+import { createErrorResponse, AppError } from '@send/shared';
 
 export class StudentController {
   private model: StudentModel;
@@ -15,7 +16,9 @@ export class StudentController {
       const student = await this.model.create(studentData);
       res.status(201).json(student);
     } catch (error) {
-      res.status(500).json({ error: 'Failed to create student' });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Failed to create student', 500)));
     }
   }
 
@@ -25,11 +28,15 @@ export class StudentController {
       const studentData = req.body as StudentUpdateInput;
       const student = await this.model.update(id, studentData);
       if (!student) {
-        return res.status(404).json({ error: 'Student not found' });
+        return res
+          .status(404)
+          .json(createErrorResponse(new AppError('Student not found', 404)));
       }
       res.json(student);
     } catch (error) {
-      res.status(500).json({ error: 'Failed to update student' });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Failed to update student', 500)));
     }
   }
 
@@ -38,11 +45,15 @@ export class StudentController {
       const { id } = req.params;
       const student = await this.model.findById(id);
       if (!student) {
-        return res.status(404).json({ error: 'Student not found' });
+        return res
+          .status(404)
+          .json(createErrorResponse(new AppError('Student not found', 404)));
       }
       res.json(student);
     } catch (error) {
-      res.status(500).json({ error: 'Failed to get student' });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Failed to get student', 500)));
     }
   }
 
@@ -53,7 +64,9 @@ export class StudentController {
       const students = await this.model.findAll(where);
       res.json(students);
     } catch (error) {
-      res.status(500).json({ error: 'Failed to get students' });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Failed to get students', 500)));
     }
   }
 
@@ -62,7 +75,9 @@ export class StudentController {
       const students = await this.model.findAll();
       res.json(students);
     } catch (error) {
-      res.status(500).json({ error: 'Failed to get students' });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Failed to get students', 500)));
     }
   }
 
@@ -72,7 +87,9 @@ export class StudentController {
       await this.model.delete(id);
       res.status(204).send();
     } catch (error) {
-      res.status(500).json({ error: 'Failed to delete student' });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Failed to delete student', 500)));
     }
   }
 } 

--- a/packages/tracking-service/src/__tests__/controllers/tracking.controller.test.ts
+++ b/packages/tracking-service/src/__tests__/controllers/tracking.controller.test.ts
@@ -47,7 +47,10 @@ describe('TrackingController - getTrackingStatus', () => {
     await controller.getTrackingStatus(req as Request, res as Response);
 
     expect(res.status).toHaveBeenCalledWith(404);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Run not found' });
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: { code: 'AppError', message: 'Run not found' }
+    });
   });
 
   it('handles errors from service', async () => {
@@ -59,6 +62,9 @@ describe('TrackingController - getTrackingStatus', () => {
     await controller.getTrackingStatus(req as Request, res as Response);
 
     expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Failed to get tracking status' });
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: { code: 'AppError', message: 'Failed to get tracking status' }
+    });
   });
 });

--- a/packages/tracking-service/src/api/controllers/tracking.controller.ts
+++ b/packages/tracking-service/src/api/controllers/tracking.controller.ts
@@ -3,6 +3,7 @@ import { TrackingService } from '../../infra/services/tracking.service';
 import { Run } from '@shared/types/run';
 import { Location } from '@shared/types/tracking';
 import { logger } from '@shared/logger';
+import { createErrorResponse, AppError } from '@send/shared';
 
 export class TrackingController {
   constructor(private readonly trackingService: TrackingService) {}
@@ -14,7 +15,9 @@ export class TrackingController {
       res.status(200).json({ message: 'Tracking started' });
     } catch (error) {
       logger.error('Failed to start tracking:', error);
-      res.status(500).json({ error: 'Failed to start tracking' });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Failed to start tracking', 500)));
     }
   }
 
@@ -26,7 +29,9 @@ export class TrackingController {
       res.status(200).json({ message: 'Location updated' });
     } catch (error) {
       logger.error('Failed to update location:', error);
-      res.status(500).json({ error: 'Failed to update location' });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Failed to update location', 500)));
     }
   }
 
@@ -37,7 +42,9 @@ export class TrackingController {
       res.status(200).json({ message: 'Tracking stopped' });
     } catch (error) {
       logger.error('Failed to stop tracking:', error);
-      res.status(500).json({ error: 'Failed to stop tracking' });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Failed to stop tracking', 500)));
     }
   }
 
@@ -46,13 +53,17 @@ export class TrackingController {
       const { runId } = req.params;
       const status = this.trackingService.getTrackingStatus(runId);
       if (!status) {
-        res.status(404).json({ error: 'Run not found' });
+        res
+          .status(404)
+          .json(createErrorResponse(new AppError('Run not found', 404)));
         return;
       }
       res.status(200).json({ status });
     } catch (error) {
       logger.error('Failed to get tracking status:', error);
-      res.status(500).json({ error: 'Failed to get tracking status' });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Failed to get tracking status', 500)));
     }
   }
 
@@ -61,7 +72,9 @@ export class TrackingController {
       const { routeId } = req.params;
       const location = this.trackingService.getLatestLocation(routeId);
       if (!location) {
-        res.status(404).json({ error: 'Location not found' });
+        res
+          .status(404)
+          .json(createErrorResponse(new AppError('Location not found', 404)));
         return;
       }
       res.status(200).json({
@@ -71,7 +84,9 @@ export class TrackingController {
       });
     } catch (error) {
       logger.error('Failed to get latest location:', error);
-      res.status(500).json({ error: 'Failed to get latest location' });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Failed to get latest location', 500)));
     }
   }
 }

--- a/packages/user-service/src/__tests__/controllers/user.controller.test.ts
+++ b/packages/user-service/src/__tests__/controllers/user.controller.test.ts
@@ -80,7 +80,10 @@ describe('UserController', () => {
       await UserController.login(req as Request, res as Response);
 
       expect(res.status).toHaveBeenCalledWith(401);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Invalid credentials' });
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: { code: 'AppError', message: 'Invalid credentials' }
+      });
     });
   });
 });

--- a/packages/vehicle-service/src/__tests__/controllers/vehicle.controller.test.ts
+++ b/packages/vehicle-service/src/__tests__/controllers/vehicle.controller.test.ts
@@ -75,7 +75,10 @@ describe('VehicleController', () => {
         .send({});
 
       expect(response.status).toBe(500);
-      expect(response.body).toEqual({ error: 'Failed to create vehicle' });
+      expect(response.body).toEqual({
+        success: false,
+        error: { code: 'AppError', message: 'Failed to create vehicle' }
+      });
     });
   });
 
@@ -109,7 +112,10 @@ describe('VehicleController', () => {
       const response = await request(app).get('/vehicles/1');
 
       expect(response.status).toBe(404);
-      expect(response.body).toEqual({ error: 'Vehicle not found' });
+      expect(response.body).toEqual({
+        success: false,
+        error: { code: 'AppError', message: 'Vehicle not found' }
+      });
     });
 
     it('should handle errors', async () => {
@@ -118,7 +124,10 @@ describe('VehicleController', () => {
       const response = await request(app).get('/vehicles/1');
 
       expect(response.status).toBe(500);
-      expect(response.body).toEqual({ error: 'Failed to get vehicle' });
+      expect(response.body).toEqual({
+        success: false,
+        error: { code: 'AppError', message: 'Failed to get vehicle' }
+      });
     });
   });
 
@@ -160,7 +169,10 @@ describe('VehicleController', () => {
         .send({});
 
       expect(response.status).toBe(404);
-      expect(response.body).toEqual({ error: 'Vehicle not found' });
+      expect(response.body).toEqual({
+        success: false,
+        error: { code: 'AppError', message: 'Vehicle not found' }
+      });
     });
 
     it('should handle errors', async () => {
@@ -171,7 +183,10 @@ describe('VehicleController', () => {
         .send({});
 
       expect(response.status).toBe(500);
-      expect(response.body).toEqual({ error: 'Failed to update vehicle' });
+      expect(response.body).toEqual({
+        success: false,
+        error: { code: 'AppError', message: 'Failed to update vehicle' }
+      });
     });
   });
 
@@ -191,7 +206,10 @@ describe('VehicleController', () => {
       const response = await request(app).delete('/vehicles/1');
 
       expect(response.status).toBe(500);
-      expect(response.body).toEqual({ error: 'Failed to delete vehicle' });
+      expect(response.body).toEqual({
+        success: false,
+        error: { code: 'AppError', message: 'Failed to delete vehicle' }
+      });
     });
   });
 
@@ -226,7 +244,10 @@ describe('VehicleController', () => {
       const response = await request(app).get('/vehicles');
 
       expect(response.status).toBe(500);
-      expect(response.body).toEqual({ error: 'Failed to list vehicles' });
+      expect(response.body).toEqual({
+        success: false,
+        error: { code: 'AppError', message: 'Failed to list vehicles' }
+      });
     });
   });
 
@@ -268,7 +289,10 @@ describe('VehicleController', () => {
         .send({});
 
       expect(response.status).toBe(404);
-      expect(response.body).toEqual({ error: 'Vehicle not found' });
+      expect(response.body).toEqual({
+        success: false,
+        error: { code: 'AppError', message: 'Vehicle not found' }
+      });
     });
 
     it('should handle errors', async () => {
@@ -279,7 +303,10 @@ describe('VehicleController', () => {
         .send({});
 
       expect(response.status).toBe(500);
-      expect(response.body).toEqual({ error: 'Failed to add maintenance record' });
+      expect(response.body).toEqual({
+        success: false,
+        error: { code: 'AppError', message: 'Failed to add maintenance record' }
+      });
     });
   });
 
@@ -318,7 +345,10 @@ describe('VehicleController', () => {
         .send({ status: VehicleStatus.MAINTENANCE });
 
       expect(response.status).toBe(404);
-      expect(response.body).toEqual({ error: 'Vehicle not found' });
+      expect(response.body).toEqual({
+        success: false,
+        error: { code: 'AppError', message: 'Vehicle not found' }
+      });
     });
 
     it('should handle errors', async () => {
@@ -329,7 +359,10 @@ describe('VehicleController', () => {
         .send({ status: VehicleStatus.MAINTENANCE });
 
       expect(response.status).toBe(500);
-      expect(response.body).toEqual({ error: 'Failed to update vehicle status' });
+      expect(response.body).toEqual({
+        success: false,
+        error: { code: 'AppError', message: 'Failed to update vehicle status' }
+      });
     });
   });
 
@@ -370,7 +403,10 @@ describe('VehicleController', () => {
         .send({ runId: 'run1' });
 
       expect(response.status).toBe(404);
-      expect(response.body).toEqual({ error: 'Vehicle not found' });
+      expect(response.body).toEqual({
+        success: false,
+        error: { code: 'AppError', message: 'Vehicle not found' }
+      });
     });
 
     it('should handle errors', async () => {
@@ -381,7 +417,10 @@ describe('VehicleController', () => {
         .send({ runId: 'run1' });
 
       expect(response.status).toBe(500);
-      expect(response.body).toEqual({ error: 'Failed to assign vehicle to run' });
+      expect(response.body).toEqual({
+        success: false,
+        error: { code: 'AppError', message: 'Failed to assign vehicle to run' }
+      });
     });
   });
 
@@ -416,7 +455,10 @@ describe('VehicleController', () => {
       const response = await request(app).post('/vehicles/1/release');
 
       expect(response.status).toBe(404);
-      expect(response.body).toEqual({ error: 'Vehicle not found' });
+      expect(response.body).toEqual({
+        success: false,
+        error: { code: 'AppError', message: 'Vehicle not found' }
+      });
     });
 
     it('should handle errors', async () => {
@@ -425,7 +467,10 @@ describe('VehicleController', () => {
       const response = await request(app).post('/vehicles/1/release');
 
       expect(response.status).toBe(500);
-      expect(response.body).toEqual({ error: 'Failed to release vehicle from run' });
+      expect(response.body).toEqual({
+        success: false,
+        error: { code: 'AppError', message: 'Failed to release vehicle from run' }
+      });
     });
   });
 }); 

--- a/packages/vehicle-service/src/api/controllers/vehicle.controller.ts
+++ b/packages/vehicle-service/src/api/controllers/vehicle.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { VehicleService } from '../../services/vehicle.service';
 import { CreateVehicleDto, UpdateVehicleDto, TelemetryRecordDto } from '../dto/vehicle.dto';
 import { VehicleStatus } from '@shared/types/vehicle';
+import { createErrorResponse, AppError } from '@send/shared';
 
 export class VehicleController {
   constructor(private readonly vehicleService: VehicleService) {}
@@ -11,7 +12,9 @@ export class VehicleController {
       const vehicle = await this.vehicleService.createVehicle(req.body as CreateVehicleDto);
       res.status(201).json(vehicle);
     } catch (error) {
-      res.status(500).json({ message: 'Error creating vehicle', error });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Error creating vehicle', 500)));
     }
   }
 
@@ -19,12 +22,16 @@ export class VehicleController {
     try {
       const vehicle = await this.vehicleService.updateVehicle(req.params.id, req.body as UpdateVehicleDto);
       if (!vehicle) {
-        res.status(404).json({ message: 'Vehicle not found' });
+        res
+          .status(404)
+          .json(createErrorResponse(new AppError('Vehicle not found', 404)));
         return;
       }
       res.json(vehicle);
     } catch (error) {
-      res.status(500).json({ message: 'Error updating vehicle', error });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Error updating vehicle', 500)));
     }
   }
 
@@ -32,12 +39,16 @@ export class VehicleController {
     try {
       const vehicle = await this.vehicleService.getVehicleById(req.params.id);
       if (!vehicle) {
-        res.status(404).json({ message: 'Vehicle not found' });
+        res
+          .status(404)
+          .json(createErrorResponse(new AppError('Vehicle not found', 404)));
         return;
       }
       res.json(vehicle);
     } catch (error) {
-      res.status(500).json({ message: 'Error getting vehicle', error });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Error getting vehicle', 500)));
     }
   }
 
@@ -46,7 +57,9 @@ export class VehicleController {
       const { vehicles, total } = await this.vehicleService.getAllVehicles(req.query);
       res.json({ vehicles, total });
     } catch (error) {
-      res.status(500).json({ message: 'Error getting vehicles', error });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Error getting vehicles', 500)));
     }
   }
 
@@ -54,12 +67,16 @@ export class VehicleController {
     try {
       const success = await this.vehicleService.deleteVehicle(req.params.id);
       if (!success) {
-        res.status(404).json({ message: 'Vehicle not found' });
+        res
+          .status(404)
+          .json(createErrorResponse(new AppError('Vehicle not found', 404)));
         return;
       }
       res.status(204).send();
     } catch (error) {
-      res.status(500).json({ message: 'Error deleting vehicle', error });
+      res
+        .status(500)
+        .json(createErrorResponse(new AppError('Error deleting vehicle', 500)));
     }
   }
 
@@ -68,7 +85,11 @@ export class VehicleController {
       const vehicle = await this.vehicleService.updateVehicle(req.params.id, { status: req.body.status });
       res.json(vehicle);
     } catch (error) {
-      res.status(500).json({ message: 'Error updating vehicle status', error });
+      res
+        .status(500)
+        .json(
+          createErrorResponse(new AppError('Error updating vehicle status', 500))
+        );
     }
   }
 
@@ -77,7 +98,11 @@ export class VehicleController {
       const vehicle = await this.vehicleService.assignVehicleToRun(req.params.id, req.body.runId);
       res.json(vehicle);
     } catch (error) {
-      res.status(500).json({ message: 'Error assigning vehicle to run', error });
+      res
+        .status(500)
+        .json(
+          createErrorResponse(new AppError('Error assigning vehicle to run', 500))
+        );
     }
   }
 
@@ -86,7 +111,13 @@ export class VehicleController {
       const vehicle = await this.vehicleService.unassignVehicleFromRun(req.params.id);
       res.json(vehicle);
     } catch (error) {
-      res.status(500).json({ message: 'Error unassigning vehicle from run', error });
+      res
+        .status(500)
+        .json(
+          createErrorResponse(
+            new AppError('Error unassigning vehicle from run', 500)
+          )
+        );
     }
   }
 
@@ -95,7 +126,11 @@ export class VehicleController {
       const vehicles = await this.vehicleService.getAvailableVehicles();
       res.json(vehicles);
     } catch (error) {
-      res.status(500).json({ message: 'Error getting available vehicles', error });
+      res
+        .status(500)
+        .json(
+          createErrorResponse(new AppError('Error getting available vehicles', 500))
+        );
     }
   }
 
@@ -104,7 +139,11 @@ export class VehicleController {
       await this.vehicleService.addMaintenanceRecord(req.params.id, req.body);
       res.status(201).send();
     } catch (error) {
-      res.status(500).json({ message: 'Error adding maintenance record', error });
+      res
+        .status(500)
+        .json(
+          createErrorResponse(new AppError('Error adding maintenance record', 500))
+        );
     }
   }
 
@@ -113,7 +152,11 @@ export class VehicleController {
       const history = await this.vehicleService.getMaintenanceHistory(req.params.id);
       res.json(history);
     } catch (error) {
-      res.status(500).json({ message: 'Error getting maintenance history', error });
+      res
+        .status(500)
+        .json(
+          createErrorResponse(new AppError('Error getting maintenance history', 500))
+        );
     }
   }
 
@@ -125,7 +168,11 @@ export class VehicleController {
       );
       res.status(201).json(record);
     } catch (error) {
-      res.status(500).json({ message: 'Error adding telemetry record', error });
+      res
+        .status(500)
+        .json(
+          createErrorResponse(new AppError('Error adding telemetry record', 500))
+        );
     }
   }
 
@@ -133,12 +180,18 @@ export class VehicleController {
     try {
       const record = await this.vehicleService.getLatestTelemetry(req.params.id);
       if (!record) {
-        res.status(404).json({ message: 'Telemetry not found' });
+        res
+          .status(404)
+          .json(createErrorResponse(new AppError('Telemetry not found', 404)));
         return;
       }
       res.json(record);
     } catch (error) {
-      res.status(500).json({ message: 'Error getting latest telemetry', error });
+      res
+        .status(500)
+        .json(
+          createErrorResponse(new AppError('Error getting latest telemetry', 500))
+        );
     }
   }
 }


### PR DESCRIPTION
## Summary
- use `createErrorResponse(new AppError(...))` in vehicle, student, tracking, and invoice controllers
- update corresponding tests for new error format

## Testing
- `pnpm test` *(fails: Lerna running target test for 13 projects failed)*

------
https://chatgpt.com/codex/tasks/task_e_6844861738d48333b922c5f4c2b7d007