### PR TITLE
Standardize controller success responses

### DIFF
--- a/packages/admin-service/src/api/controllers/admin.controller.ts
+++ b/packages/admin-service/src/api/controllers/admin.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { MetricsService } from '../../services/metrics.service';
 import { ConfigService } from '../../services/config.service';
 import { ReportService } from '../../services/report.service';
+import { createSuccessResponse } from '@send/shared';
 
 export class AdminController {
   constructor(
@@ -12,21 +13,21 @@ export class AdminController {
 
   async metrics(req: Request, res: Response): Promise<void> {
     const metrics = await this.metricsService.getMetrics();
-    res.json(metrics);
+    res.json(createSuccessResponse(metrics));
   }
 
   async reports(req: Request, res: Response): Promise<void> {
     const reports = await this.reportService.getReports();
-    res.json(reports);
+    res.json(createSuccessResponse(reports));
   }
 
   async getConfig(req: Request, res: Response): Promise<void> {
     const config = await this.configService.getConfig();
-    res.json(config);
+    res.json(createSuccessResponse(config));
   }
 
   async updateConfig(req: Request, res: Response): Promise<void> {
     const config = await this.configService.updateConfig(req.body);
-    res.json(config);
+    res.json(createSuccessResponse(config));
   }
 }

--- a/packages/document-service/src/api/controllers/document.controller.ts
+++ b/packages/document-service/src/api/controllers/document.controller.ts
@@ -3,7 +3,7 @@ import { DocumentService } from '../../services/document.service';
 import { Document } from '@shared/types/document';
 import { logger } from '@shared/logger';
 import { AppError } from '@shared/errors';
-import { createErrorResponse } from '@shared/responses';
+import { createErrorResponse, createSuccessResponse } from '@shared/responses';
 
 export class DocumentController {
   constructor(private readonly documentService: DocumentService) {}
@@ -18,13 +18,18 @@ export class DocumentController {
           .json(createErrorResponse(new AppError('File is required', 400)));
         return;
       }
-      const document = await this.documentService.uploadDocument(userId, {
-        originalname: file.originalname,
-        mimetype: file.mimetype,
-        size: file.size,
-        buffer: file.buffer,
-      }, type, metadata || {});
-      res.status(201).json(document);
+      const document = await this.documentService.uploadDocument(
+        userId,
+        {
+          originalname: file.originalname,
+          mimetype: file.mimetype,
+          size: file.size,
+          buffer: file.buffer
+        },
+        type,
+        metadata || {}
+      );
+      res.status(201).json(createSuccessResponse(document));
     } catch (error) {
       logger.error('Failed to upload document:', error);
       res.status(500).json(createErrorResponse(error as Error));
@@ -41,7 +46,7 @@ export class DocumentController {
           .json(createErrorResponse(new AppError('Document not found', 404)));
         return;
       }
-      res.json(doc);
+      res.json(createSuccessResponse(doc));
     } catch (error) {
       logger.error('Failed to get document:', error);
       res.status(500).json(createErrorResponse(error as Error));
@@ -55,7 +60,7 @@ export class DocumentController {
         userId: userId as string | undefined,
         type: type as string | undefined,
       });
-      res.json(docs);
+      res.json(createSuccessResponse(docs));
     } catch (error) {
       logger.error('Failed to list documents:', error);
       res.status(500).json(createErrorResponse(error as Error));
@@ -84,7 +89,7 @@ export class DocumentController {
         grantedBy,
         expiresAt ? new Date(expiresAt) : undefined
       );
-      res.json(access);
+      res.json(createSuccessResponse(access));
     } catch (error) {
       logger.error('Failed to update document access:', error);
       res.status(500).json(createErrorResponse(error as Error));
@@ -96,7 +101,7 @@ export class DocumentController {
       const { id } = req.params;
       const metadata = req.body.metadata;
       const doc = await this.documentService.updateDocumentMetadata(id, metadata);
-      res.json(doc);
+      res.json(createSuccessResponse(doc));
     } catch (error) {
       logger.error('Failed to update document metadata:', error);
       res.status(500).json(createErrorResponse(error as Error));

--- a/packages/driver-service/src/api/controllers/driver.controller.ts
+++ b/packages/driver-service/src/api/controllers/driver.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import { DriverService } from '../../infra/services/driver.service';
 import { Driver, DriverStatus } from '@shared/types/driver';
-import { LoggerService } from '@send/shared';
+import { LoggerService, createSuccessResponse } from '@send/shared';
 import { createErrorResponse, AppError } from '@send/shared';
 
 const logger = new LoggerService({ serviceName: 'driver-service' });
@@ -13,7 +13,7 @@ export class DriverController {
     try {
       const driver = req.body as Omit<Driver, 'id' | 'createdAt' | 'updatedAt'>;
       const createdDriver = await this.driverService.createDriver(driver);
-      res.status(201).json(createdDriver);
+      res.status(201).json(createSuccessResponse(createdDriver));
     } catch (error) {
       logger.error('Failed to create driver:', error);
       res.status(500).json(createErrorResponse(new AppError('Failed to create driver', 500)));
@@ -25,7 +25,7 @@ export class DriverController {
       const { id } = req.params;
       const driver = req.body as Partial<Driver>;
       const updatedDriver = await this.driverService.updateDriver(id, driver);
-      res.status(200).json(updatedDriver);
+      res.status(200).json(createSuccessResponse(updatedDriver));
     } catch (error) {
       logger.error('Failed to update driver:', error);
       res.status(500).json(createErrorResponse(new AppError('Failed to update driver', 500)));
@@ -40,7 +40,7 @@ export class DriverController {
         res.status(404).json(createErrorResponse(new AppError('Driver not found', 404)));
         return;
       }
-      res.status(200).json(driver);
+      res.status(200).json(createSuccessResponse(driver));
     } catch (error) {
       logger.error('Failed to get driver:', error);
       res.status(500).json(createErrorResponse(new AppError('Failed to get driver', 500)));
@@ -50,7 +50,7 @@ export class DriverController {
   async getDrivers(req: Request, res: Response): Promise<void> {
     try {
       const drivers = await this.driverService.getDrivers();
-      res.status(200).json(drivers);
+      res.status(200).json(createSuccessResponse(drivers));
     } catch (error) {
       logger.error('Failed to get drivers:', error);
       res.status(500).json(createErrorResponse(new AppError('Failed to get drivers', 500)));
@@ -73,7 +73,7 @@ export class DriverController {
       const { id } = req.params;
       const { status } = req.body as { status: DriverStatus };
       const updatedDriver = await this.driverService.updateDriverStatus(id, status);
-      res.status(200).json(updatedDriver);
+      res.status(200).json(createSuccessResponse(updatedDriver));
     } catch (error) {
       logger.error('Failed to update driver status:', error);
       res.status(500).json(createErrorResponse(new AppError('Failed to update driver status', 500)));
@@ -85,7 +85,7 @@ export class DriverController {
       const { driverId } = req.params;
       const { runId } = req.body as { runId: string };
       const updatedDriver = await this.driverService.assignDriverToRun(driverId, runId);
-      res.status(200).json(updatedDriver);
+      res.status(200).json(createSuccessResponse(updatedDriver));
     } catch (error) {
       logger.error('Failed to assign driver to run:', error);
       res.status(500).json(createErrorResponse(new AppError('Failed to assign driver to run', 500)));
@@ -96,7 +96,7 @@ export class DriverController {
     try {
       const { driverId } = req.params;
       const updatedDriver = await this.driverService.unassignDriverFromRun(driverId);
-      res.status(200).json(updatedDriver);
+      res.status(200).json(createSuccessResponse(updatedDriver));
     } catch (error) {
       logger.error('Failed to unassign driver from run:', error);
       res.status(500).json(createErrorResponse(new AppError('Failed to unassign driver from run', 500)));
@@ -107,7 +107,7 @@ export class DriverController {
     try {
       const { id } = req.params;
       const availability = await this.driverService.getDriverAvailability(id);
-      res.status(200).json(availability);
+      res.status(200).json(createSuccessResponse(availability));
     } catch (error) {
       logger.error('Failed to get driver availability:', error);
       res.status(500).json(createErrorResponse(new AppError('Failed to get driver availability', 500)));
@@ -119,7 +119,7 @@ export class DriverController {
       const { id } = req.params;
       const slots = req.body as { startTime: Date; endTime: Date }[];
       const availability = await this.driverService.updateDriverAvailability(id, slots);
-      res.status(200).json(availability);
+      res.status(200).json(createSuccessResponse(availability));
     } catch (error) {
       logger.error('Failed to update driver availability:', error);
       res.status(500).json(createErrorResponse(new AppError('Failed to update driver availability', 500)));
@@ -129,7 +129,7 @@ export class DriverController {
   async getAvailableDrivers(req: Request, res: Response): Promise<void> {
     try {
       const drivers = await this.driverService.getAvailableDrivers();
-      res.status(200).json(drivers);
+      res.status(200).json(createSuccessResponse(drivers));
     } catch (error) {
       logger.error('Failed to get available drivers:', error);
       res.status(500).json(createErrorResponse(new AppError('Failed to get available drivers', 500)));
@@ -140,7 +140,7 @@ export class DriverController {
     try {
       const { driverId } = req.params;
       const performance = await this.driverService.getDriverPerformance(driverId);
-      res.status(200).json(performance);
+      res.status(200).json(createSuccessResponse(performance));
     } catch (error) {
       logger.error('Failed to get driver performance:', error);
       res.status(500).json(createErrorResponse(new AppError('Failed to get driver performance', 500)));

--- a/packages/incident-service/src/api/controllers/incident.controller.ts
+++ b/packages/incident-service/src/api/controllers/incident.controller.ts
@@ -1,6 +1,11 @@
 import { Request, Response } from 'express';
 import { IncidentService } from '../../services/incident.service';
-import { LoggerService, createErrorResponse, AppError } from '@send/shared';
+import {
+  LoggerService,
+  createErrorResponse,
+  createSuccessResponse,
+  AppError
+} from '@send/shared';
 
 const logger = new LoggerService({ serviceName: 'incident-service' });
 
@@ -10,7 +15,7 @@ export class IncidentController {
   async create(req: Request, res: Response): Promise<void> {
     try {
       const incident = await this.incidentService.createIncident(req.body);
-      res.status(201).json(incident);
+      res.status(201).json(createSuccessResponse(incident));
     } catch (err) {
       logger.error('Failed to create incident', { error: err });
       res.status(500).json(createErrorResponse(new AppError('Failed to create incident', 500)));
@@ -19,7 +24,7 @@ export class IncidentController {
 
   async list(req: Request, res: Response): Promise<void> {
     const incidents = await this.incidentService.listIncidents();
-    res.json(incidents);
+    res.json(createSuccessResponse(incidents));
   }
 
   async getById(req: Request, res: Response): Promise<void> {
@@ -28,7 +33,7 @@ export class IncidentController {
       res.status(404).json(createErrorResponse(new AppError('Incident not found', 404)));
       return;
     }
-    res.json(incident);
+    res.json(createSuccessResponse(incident));
   }
 
   async update(req: Request, res: Response): Promise<void> {
@@ -37,7 +42,7 @@ export class IncidentController {
       res.status(404).json(createErrorResponse(new AppError('Incident not found', 404)));
       return;
     }
-    res.json(incident);
+    res.json(createSuccessResponse(incident));
   }
 
   async remove(req: Request, res: Response): Promise<void> {

--- a/packages/invoicing-service/src/api/controllers/invoice.controller.ts
+++ b/packages/invoicing-service/src/api/controllers/invoice.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { InvoiceService } from '../../services/invoice.service';
 import { InvoiceStatus } from '@shared/types/invoice';
+import { createSuccessResponse } from '@send/shared';
 
 export class InvoiceController {
   constructor(private readonly invoiceService: InvoiceService) {}
@@ -8,14 +9,14 @@ export class InvoiceController {
   async create(req: Request, res: Response): Promise<void> {
     try {
       const invoice = await this.invoiceService.createInvoice(req.body);
-      res.status(201).json(invoice);
+      res.status(201).json(createSuccessResponse(invoice));
     } catch (err) {
       res.status(500).json({ error: 'Failed to create invoice' });
     }
   }
 
   async list(req: Request, res: Response): Promise<void> {
-    res.json(await this.invoiceService.listInvoices());
+    res.json(createSuccessResponse(await this.invoiceService.listInvoices()));
   }
 
   async getById(req: Request, res: Response): Promise<void> {
@@ -24,7 +25,7 @@ export class InvoiceController {
       res.status(404).json({ error: 'Invoice not found' });
       return;
     }
-    res.json(invoice);
+    res.json(createSuccessResponse(invoice));
   }
 
   async updateStatus(req: Request, res: Response): Promise<void> {
@@ -36,7 +37,7 @@ export class InvoiceController {
       res.status(404).json({ error: 'Invoice not found' });
       return;
     }
-    res.json(invoice);
+    res.json(createSuccessResponse(invoice));
   }
 
   async send(req: Request, res: Response): Promise<void> {
@@ -45,6 +46,6 @@ export class InvoiceController {
       res.status(404).json({ error: 'Invoice not found' });
       return;
     }
-    res.json(invoice);
+    res.json(createSuccessResponse(invoice));
   }
 }

--- a/packages/run-service/src/api/controllers/run.controller.ts
+++ b/packages/run-service/src/api/controllers/run.controller.ts
@@ -5,6 +5,7 @@ import { RabbitMQService } from '../../infra/messaging/rabbitmq';
 import { RouteService } from '../../infra/services/route.service';
 import { ScheduleService } from '../../infra/services/schedule.service';
 import { AppError } from '@shared/errors';
+import { createSuccessResponse } from '@send/shared';
 
 declare global {
   namespace Express {
@@ -119,7 +120,7 @@ export class RunController {
         await this.rabbitMQ.publishNotification(notification);
       }
 
-      res.json({ run });
+      res.json(createSuccessResponse({ run }));
     } catch (error) {
       next(error);
     }
@@ -145,7 +146,7 @@ export class RunController {
         await this.rabbitMQ.publishNotification(notification);
       }
 
-      res.json({ run });
+      res.json(createSuccessResponse({ run }));
     } catch (error) {
       next(error);
     }
@@ -162,7 +163,7 @@ export class RunController {
       // Publish run completed event
       await this.rabbitMQ.publishRunEvent('RUN_COMPLETED', run);
 
-      res.json({ run });
+      res.json(createSuccessResponse({ run }));
     } catch (error) {
       next(error);
     }
@@ -175,7 +176,7 @@ export class RunController {
       if (!run) {
         throw new AppError('Run not found', 404);
       }
-      res.json({ run });
+      res.json(createSuccessResponse({ run }));
     } catch (error) {
       next(error);
     }
@@ -189,7 +190,7 @@ export class RunController {
         type: type as RunType,
         driverId: driverId as string
       });
-      res.json({ runs });
+      res.json(createSuccessResponse({ runs }));
     } catch (error) {
       next(error);
     }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,4 +5,8 @@ export * from './db/database.service';
 export * from './logging/logger.service';
 export * from './health/health.check';
 export * from './responses';
+export {
+  createSuccessResponse,
+  createPaginatedResponse
+} from './responses/success';
 

--- a/packages/student-service/src/__tests__/controllers/student.controller.test.ts
+++ b/packages/student-service/src/__tests__/controllers/student.controller.test.ts
@@ -81,7 +81,9 @@ describe('StudentController', () => {
         data: mockStudent,
       });
       expect(res.status).toHaveBeenCalledWith(201);
-      expect(res.json).toHaveBeenCalledWith({ student: mockStudent });
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: { student: mockStudent } })
+      );
     });
 
     it('should return 500 on error', async () => {
@@ -115,7 +117,9 @@ describe('StudentController', () => {
       await studentController.getStudent(req as Request, res as Response);
 
       expect(studentModel.findById).toHaveBeenCalledWith('student-123');
-      expect(res.json).toHaveBeenCalledWith({ student: mockStudent });
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: { student: mockStudent } })
+      );
     });
 
     it('should return 404 if student not found', async () => {
@@ -160,7 +164,9 @@ describe('StudentController', () => {
       await studentController.getStudents(req as Request, res as Response);
 
       expect(studentModel.findAll).toHaveBeenCalledWith(undefined);
-      expect(res.json).toHaveBeenCalledWith({ students: mockStudents });
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: { students: mockStudents } })
+      );
     });
 
     it('should filter students by parentId', async () => {
@@ -184,7 +190,9 @@ describe('StudentController', () => {
       await studentController.getStudents(req as Request, res as Response);
 
       expect(studentModel.findAll).toHaveBeenCalledWith({ parentId: 'parent-123' });
-      expect(res.json).toHaveBeenCalledWith({ students: mockStudents });
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: { students: mockStudents } })
+      );
     });
 
     it('should return 500 on error', async () => {
@@ -216,7 +224,9 @@ describe('StudentController', () => {
         data: mockGuardian,
       });
       expect(res.status).toHaveBeenCalledWith(201);
-      expect(res.json).toHaveBeenCalledWith({ guardian: mockGuardian });
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: { guardian: mockGuardian } })
+      );
     });
 
     it('should handle errors', async () => {
@@ -273,7 +283,9 @@ describe('StudentController', () => {
         data: mockAttendance,
       });
       expect(res.status).toHaveBeenCalledWith(201);
-      expect(res.json).toHaveBeenCalledWith({ attendance: mockAttendance });
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: { attendance: mockAttendance } })
+      );
     });
 
     it('should handle errors', async () => {

--- a/packages/student-service/src/api/controllers/student.controller.ts
+++ b/packages/student-service/src/api/controllers/student.controller.ts
@@ -1,7 +1,14 @@
 import { Request, Response, NextFunction } from 'express';
 import { StudentModel } from '../../data/models/student.model';
 import { RabbitMQService } from '../../infra/messaging/rabbitmq';
-import { Student, StudentEvent, StudentNotification, StudentCreateInput, StudentUpdateInput } from '@send/shared';
+import {
+  Student,
+  StudentEvent,
+  StudentNotification,
+  StudentCreateInput,
+  StudentUpdateInput,
+  createSuccessResponse
+} from '@send/shared';
 import { AppError } from '@shared/errors';
 
 const rabbitMQ = new RabbitMQService();
@@ -24,7 +31,7 @@ export class StudentController {
         data: student
       });
 
-      res.status(201).json({ student });
+      res.status(201).json(createSuccessResponse({ student }));
     } catch (error) {
       next(error);
     }
@@ -43,7 +50,7 @@ export class StudentController {
         data: student
       });
 
-      res.json({ student });
+      res.json(createSuccessResponse({ student }));
     } catch (error) {
       next(error);
     }
@@ -58,7 +65,7 @@ export class StudentController {
         throw new AppError('Student not found', 404);
       }
 
-      res.json({ student });
+      res.json(createSuccessResponse({ student }));
     } catch (error) {
       next(error);
     }
@@ -71,7 +78,7 @@ export class StudentController {
         parentId ? { parentId: parentId as string } : undefined
       );
 
-      res.json({ students });
+      res.json(createSuccessResponse({ students }));
     } catch (error) {
       next(error);
     }
@@ -107,7 +114,7 @@ export class StudentController {
         data: guardian
       });
 
-      res.status(201).json({ guardian });
+      res.status(201).json(createSuccessResponse({ guardian }));
     } catch (error) {
       next(error);
     }
@@ -136,7 +143,7 @@ export class StudentController {
         data: attendance
       });
 
-      res.status(201).json({ attendance });
+      res.status(201).json(createSuccessResponse({ attendance }));
     } catch (error) {
       next(error);
     }

--- a/packages/student-service/src/api/routes/student.routes.ts
+++ b/packages/student-service/src/api/routes/student.routes.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response, RequestHandler } from 'express';
 import { StudentModel } from '../../data/models/student.model';
-import { StudentCreateInput, StudentUpdateInput } from '@send/shared';
+import { StudentCreateInput, StudentUpdateInput, createSuccessResponse } from '@send/shared';
 import { authenticate } from '@send/shared/security/auth';
 
 const router = Router();
@@ -14,7 +14,7 @@ router.post('/', authenticate(), (async (req: Request, res: Response) => {
       parentId: req.user?.id || ''
     };
     const student = await studentModel.create(studentData);
-    res.status(201).json(student);
+    res.status(201).json(createSuccessResponse(student));
   } catch (error) {
     res.status(500).json({ error: 'Failed to create student' });
   }
@@ -24,7 +24,7 @@ router.post('/', authenticate(), (async (req: Request, res: Response) => {
 router.get('/', authenticate(), (async (req: Request, res: Response) => {
   try {
     const students = await studentModel.findAll({ parentId: req.user?.id });
-    res.json(students);
+    res.json(createSuccessResponse(students));
   } catch (error) {
     res.status(500).json({ error: 'Failed to get students' });
   }
@@ -37,7 +37,7 @@ router.get('/:id', authenticate(), (async (req: Request, res: Response) => {
     if (!student) {
       return res.status(404).json({ error: 'Student not found' });
     }
-    res.json(student);
+    res.json(createSuccessResponse(student));
   } catch (error) {
     res.status(500).json({ error: 'Failed to get student' });
   }
@@ -53,8 +53,11 @@ router.put('/:id', authenticate(), (async (req: Request, res: Response) => {
     if (student.parentId !== req.user?.id) {
       return res.status(403).json({ error: 'Not authorized to update this student' });
     }
-    const updatedStudent = await studentModel.update(req.params.id, req.body as StudentUpdateInput);
-    res.json(updatedStudent);
+    const updatedStudent = await studentModel.update(
+      req.params.id,
+      req.body as StudentUpdateInput
+    );
+    res.json(createSuccessResponse(updatedStudent));
   } catch (error) {
     res.status(500).json({ error: 'Failed to update student' });
   }
@@ -81,7 +84,7 @@ router.delete('/:id', authenticate(), (async (req: Request, res: Response) => {
 router.post('/:id/add-guardian', authenticate(), (async (req: Request, res: Response) => {
   try {
     const guardian = await studentModel.addGuardian(req.params.id, req.body);
-    res.status(201).json(guardian);
+    res.status(201).json(createSuccessResponse(guardian));
   } catch (error) {
     res.status(500).json({ error: 'Failed to add guardian' });
   }
@@ -101,7 +104,7 @@ router.delete('/:id/remove-guardian', authenticate(), (async (req: Request, res:
 router.post('/:id/attendance', authenticate(), (async (req: Request, res: Response) => {
   try {
     const attendance = await studentModel.recordAttendance(req.params.id, req.body);
-    res.status(201).json(attendance);
+    res.status(201).json(createSuccessResponse(attendance));
   } catch (error) {
     res.status(500).json({ error: 'Failed to record attendance' });
   }

--- a/packages/student-service/src/controllers/student.controller.ts
+++ b/packages/student-service/src/controllers/student.controller.ts
@@ -1,6 +1,12 @@
 import { Request, Response } from 'express';
 import { StudentModel } from '../data/models/student.model';
-import { Student, StudentCreateInput, StudentUpdateInput, StudentWhereInput } from '@shared/types/student';
+import {
+  Student,
+  StudentCreateInput,
+  StudentUpdateInput,
+  StudentWhereInput
+} from '@shared/types/student';
+import { createSuccessResponse } from '@send/shared';
 
 export class StudentController {
   private model: StudentModel;
@@ -13,7 +19,7 @@ export class StudentController {
     try {
       const studentData = req.body as StudentCreateInput;
       const student = await this.model.create(studentData);
-      res.status(201).json(student);
+      res.status(201).json(createSuccessResponse(student));
     } catch (error) {
       res.status(500).json({ error: 'Failed to create student' });
     }
@@ -27,7 +33,7 @@ export class StudentController {
       if (!student) {
         return res.status(404).json({ error: 'Student not found' });
       }
-      res.json(student);
+      res.json(createSuccessResponse(student));
     } catch (error) {
       res.status(500).json({ error: 'Failed to update student' });
     }
@@ -40,7 +46,7 @@ export class StudentController {
       if (!student) {
         return res.status(404).json({ error: 'Student not found' });
       }
-      res.json(student);
+      res.json(createSuccessResponse(student));
     } catch (error) {
       res.status(500).json({ error: 'Failed to get student' });
     }
@@ -51,7 +57,7 @@ export class StudentController {
       const { parentId } = req.params;
       const where: StudentWhereInput = { parentId };
       const students = await this.model.findAll(where);
-      res.json(students);
+      res.json(createSuccessResponse(students));
     } catch (error) {
       res.status(500).json({ error: 'Failed to get students' });
     }
@@ -60,7 +66,7 @@ export class StudentController {
   async getAllStudents(req: Request, res: Response) {
     try {
       const students = await this.model.findAll();
-      res.json(students);
+      res.json(createSuccessResponse(students));
     } catch (error) {
       res.status(500).json({ error: 'Failed to get students' });
     }

--- a/packages/tracking-service/src/__tests__/controllers/tracking.controller.test.ts
+++ b/packages/tracking-service/src/__tests__/controllers/tracking.controller.test.ts
@@ -37,7 +37,9 @@ describe('TrackingController - getTrackingStatus', () => {
 
     expect(service.getTrackingStatus).toHaveBeenCalledWith('run1');
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({ status: 'IN_PROGRESS' });
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, data: { status: 'IN_PROGRESS' } })
+    );
   });
 
   it('returns 404 when run not found', async () => {

--- a/packages/tracking-service/src/api/controllers/tracking.controller.ts
+++ b/packages/tracking-service/src/api/controllers/tracking.controller.ts
@@ -3,6 +3,7 @@ import { TrackingService } from '../../infra/services/tracking.service';
 import { Run } from '@shared/types/run';
 import { Location } from '@shared/types/tracking';
 import { logger } from '@shared/logger';
+import { createSuccessResponse } from '@send/shared';
 
 export class TrackingController {
   constructor(private readonly trackingService: TrackingService) {}
@@ -11,7 +12,7 @@ export class TrackingController {
     try {
       const run = req.body as Run;
       await this.trackingService.startTracking(run);
-      res.status(200).json({ message: 'Tracking started' });
+      res.status(200).json(createSuccessResponse({ message: 'Tracking started' }));
     } catch (error) {
       logger.error('Failed to start tracking:', error);
       res.status(500).json({ error: 'Failed to start tracking' });
@@ -23,7 +24,7 @@ export class TrackingController {
       const { runId } = req.params;
       const location = req.body as Location;
       await this.trackingService.updateLocation(runId, location);
-      res.status(200).json({ message: 'Location updated' });
+      res.status(200).json(createSuccessResponse({ message: 'Location updated' }));
     } catch (error) {
       logger.error('Failed to update location:', error);
       res.status(500).json({ error: 'Failed to update location' });
@@ -34,7 +35,7 @@ export class TrackingController {
     try {
       const { runId } = req.params;
       await this.trackingService.stopTracking(runId);
-      res.status(200).json({ message: 'Tracking stopped' });
+      res.status(200).json(createSuccessResponse({ message: 'Tracking stopped' }));
     } catch (error) {
       logger.error('Failed to stop tracking:', error);
       res.status(500).json({ error: 'Failed to stop tracking' });
@@ -49,7 +50,7 @@ export class TrackingController {
         res.status(404).json({ error: 'Run not found' });
         return;
       }
-      res.status(200).json({ status });
+      res.status(200).json(createSuccessResponse({ status }));
     } catch (error) {
       logger.error('Failed to get tracking status:', error);
       res.status(500).json({ error: 'Failed to get tracking status' });
@@ -64,11 +65,13 @@ export class TrackingController {
         res.status(404).json({ error: 'Location not found' });
         return;
       }
-      res.status(200).json({
-        lat: location.latitude,
-        lng: location.longitude,
-        timestamp: location.timestamp,
-      });
+      res.status(200).json(
+        createSuccessResponse({
+          lat: location.latitude,
+          lng: location.longitude,
+          timestamp: location.timestamp
+        })
+      );
     } catch (error) {
       logger.error('Failed to get latest location:', error);
       res.status(500).json({ error: 'Failed to get latest location' });

--- a/packages/user-service/src/__tests__/controllers/user.controller.test.ts
+++ b/packages/user-service/src/__tests__/controllers/user.controller.test.ts
@@ -48,7 +48,9 @@ describe('UserController', () => {
       expect(mockedUserModel.create).toHaveBeenCalled();
       expect(publishEvent).toHaveBeenCalledWith('user.created', created);
       expect(res.status).toHaveBeenCalledWith(201);
-      expect(res.json).toHaveBeenCalledWith(created);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: created })
+      );
     });
   });
 
@@ -70,7 +72,9 @@ describe('UserController', () => {
       expect(mockedUserModel.findByEmail).toHaveBeenCalledWith('t@example.com');
       expect(mockedBcrypt.compare).toHaveBeenCalledWith('pw', 'hashed');
       expect(publishEvent).toHaveBeenCalledWith('user.login', { id: user.id, email: user.email });
-      expect(res.json).toHaveBeenCalledWith({ token: 'token' });
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: { token: 'token' } })
+      );
     });
 
     it('returns 401 for invalid credentials', async () => {

--- a/packages/user-service/src/api/controllers/user.controller.ts
+++ b/packages/user-service/src/api/controllers/user.controller.ts
@@ -11,6 +11,7 @@ import { NotificationService } from '../../../../system-notification-service/src
 import { NotificationChannel, NotificationPriority } from '../../../../system-notification-service/src/types/notification.types';
 import { publishEvent } from '../../infra/eventBus';
 import { AppError } from '@shared/errors';
+import { createSuccessResponse } from '@send/shared';
 
 export enum UserStatus {
   ACTIVE = 'ACTIVE',
@@ -44,7 +45,7 @@ export const UserController = {
 
       await publishEvent('user.created', user);
 
-      res.status(201).json(user);
+      res.status(201).json(createSuccessResponse(user));
     } catch (error: any) {
       next(error);
     }
@@ -75,7 +76,7 @@ export const UserController = {
         { expiresIn: '1d' }
       );
 
-      res.json({ token });
+      res.json(createSuccessResponse({ token }));
     } catch (error: any) {
       next(error);
     }
@@ -87,7 +88,7 @@ export const UserController = {
       if (!user) {
         throw new AppError('User not found', 404);
       }
-      res.json(user);
+      res.json(createSuccessResponse(user));
     } catch (error: any) {
       next(error);
     }
@@ -122,7 +123,7 @@ export const UserController = {
 
       await publishEvent('user.updated', user);
 
-      res.json(user);
+      res.json(createSuccessResponse(user));
     } catch (error: any) {
       next(error);
     }
@@ -141,7 +142,7 @@ export const UserController = {
         throw new AppError('Invalid current password', 401);
       }
       const updatedUser = await UserModel.update(id, { password: newPassword });
-      res.json(updatedUser);
+      res.json(createSuccessResponse(updatedUser));
     } catch (error: any) {
       next(error);
     }
@@ -179,7 +180,7 @@ export const UserController = {
         htmlContent: `<p>Your password reset token is: <strong>${token}</strong></p>`
       });
 
-      res.json({ message: 'Password reset email sent' });
+      res.json(createSuccessResponse({ message: 'Password reset email sent' }));
     } catch (error: any) {
       next(error);
     }
@@ -200,7 +201,7 @@ export const UserController = {
       await UserModel.update(record.userId, { password: newPassword });
       await PasswordResetTokenModel.delete(record.id);
 
-      res.json({ message: 'Password reset successful' });
+      res.json(createSuccessResponse({ message: 'Password reset successful' }));
     } catch (error: any) {
       next(error);
     }
@@ -209,7 +210,7 @@ export const UserController = {
   async getAllUsers(req: AuthRequest, res: Response, next: NextFunction) {
     try {
       const users = await UserModel.getAllUsers();
-      res.json(users);
+      res.json(createSuccessResponse(users));
     } catch (error: any) {
       next(error);
     }
@@ -222,7 +223,7 @@ export const UserController = {
       if (!user) {
         throw new AppError('User not found', 404);
       }
-      res.json(user);
+      res.json(createSuccessResponse(user));
     } catch (error: any) {
       next(error);
     }
@@ -239,7 +240,7 @@ export const UserController = {
 
       await publishEvent('user.updated', user);
 
-      res.json(user);
+      res.json(createSuccessResponse(user));
     } catch (error: any) {
       next(error);
     }

--- a/packages/user-service/src/api/routes/auth.routes.ts
+++ b/packages/user-service/src/api/routes/auth.routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { AuthService } from '../../core/services/AuthService';
 import { UserRepository } from '../../data/repositories/UserRepository';
 import { AppError } from '@shared/errors';
+import { createSuccessResponse } from '@send/shared';
 import { validateRequest } from '../middleware/validateRequest';
 import { loginSchema, registerSchema } from '../validators/auth.validator';
 import { getRepository } from 'typeorm';
@@ -19,7 +20,7 @@ router.post(
     try {
       const { email, password } = req.body;
       const result = await authService.login(email, password);
-      res.json(result);
+      res.json(createSuccessResponse(result));
     } catch (error) {
       next(error);
     }
@@ -32,7 +33,7 @@ router.post(
   async (req, res, next) => {
     try {
       const user = await authService.register(req.body);
-      res.status(201).json(user);
+      res.status(201).json(createSuccessResponse(user));
     } catch (error) {
       next(error);
     }
@@ -48,7 +49,7 @@ router.post('/refresh-token', async (req, res, next) => {
 
     const user = await authService.validateToken(token);
     const newToken = authService.generateToken(user);
-    res.json({ user, token: newToken });
+    res.json(createSuccessResponse({ user, token: newToken }));
   } catch (error) {
     next(error);
   }

--- a/packages/vehicle-service/src/api/controllers/vehicle.controller.ts
+++ b/packages/vehicle-service/src/api/controllers/vehicle.controller.ts
@@ -1,15 +1,29 @@
 import { Request, Response } from 'express';
 import { VehicleService } from '../../services/vehicle.service';
-import { CreateVehicleDto, UpdateVehicleDto, TelemetryRecordDto } from '../dto/vehicle.dto';
+import {
+  CreateVehicleDto,
+  UpdateVehicleDto,
+  TelemetryRecordDto
+} from '../dto/vehicle.dto';
 import { VehicleStatus } from '@shared/types/vehicle';
+import {
+  createSuccessResponse,
+  createPaginatedResponse
+} from '@send/shared';
+import {
+  createSuccessResponse,
+  createPaginatedResponse
+} from '@send/shared';
 
 export class VehicleController {
   constructor(private readonly vehicleService: VehicleService) {}
 
   async createVehicle(req: Request, res: Response): Promise<void> {
     try {
-      const vehicle = await this.vehicleService.createVehicle(req.body as CreateVehicleDto);
-      res.status(201).json(vehicle);
+      const vehicle = await this.vehicleService.createVehicle(
+        req.body as CreateVehicleDto
+      );
+      res.status(201).json(createSuccessResponse(vehicle));
     } catch (error) {
       res.status(500).json({ message: 'Error creating vehicle', error });
     }
@@ -17,12 +31,15 @@ export class VehicleController {
 
   async updateVehicle(req: Request, res: Response): Promise<void> {
     try {
-      const vehicle = await this.vehicleService.updateVehicle(req.params.id, req.body as UpdateVehicleDto);
+      const vehicle = await this.vehicleService.updateVehicle(
+        req.params.id,
+        req.body as UpdateVehicleDto
+      );
       if (!vehicle) {
         res.status(404).json({ message: 'Vehicle not found' });
         return;
       }
-      res.json(vehicle);
+      res.json(createSuccessResponse(vehicle));
     } catch (error) {
       res.status(500).json({ message: 'Error updating vehicle', error });
     }
@@ -35,7 +52,7 @@ export class VehicleController {
         res.status(404).json({ message: 'Vehicle not found' });
         return;
       }
-      res.json(vehicle);
+      res.json(createSuccessResponse(vehicle));
     } catch (error) {
       res.status(500).json({ message: 'Error getting vehicle', error });
     }
@@ -44,7 +61,9 @@ export class VehicleController {
   async getVehicles(req: Request, res: Response): Promise<void> {
     try {
       const { vehicles, total } = await this.vehicleService.getAllVehicles(req.query);
-      res.json({ vehicles, total });
+      const page = Number(req.query.page) || 1;
+      const limit = Number(req.query.limit) || 10;
+      res.json(createPaginatedResponse(vehicles, total, page, limit));
     } catch (error) {
       res.status(500).json({ message: 'Error getting vehicles', error });
     }
@@ -65,8 +84,10 @@ export class VehicleController {
 
   async updateVehicleStatus(req: Request, res: Response): Promise<void> {
     try {
-      const vehicle = await this.vehicleService.updateVehicle(req.params.id, { status: req.body.status });
-      res.json(vehicle);
+      const vehicle = await this.vehicleService.updateVehicle(req.params.id, {
+        status: req.body.status
+      });
+      res.json(createSuccessResponse(vehicle));
     } catch (error) {
       res.status(500).json({ message: 'Error updating vehicle status', error });
     }
@@ -74,8 +95,11 @@ export class VehicleController {
 
   async assignVehicleToRun(req: Request, res: Response): Promise<void> {
     try {
-      const vehicle = await this.vehicleService.assignVehicleToRun(req.params.id, req.body.runId);
-      res.json(vehicle);
+      const vehicle = await this.vehicleService.assignVehicleToRun(
+        req.params.id,
+        req.body.runId
+      );
+      res.json(createSuccessResponse(vehicle));
     } catch (error) {
       res.status(500).json({ message: 'Error assigning vehicle to run', error });
     }
@@ -84,7 +108,7 @@ export class VehicleController {
   async unassignVehicleFromRun(req: Request, res: Response): Promise<void> {
     try {
       const vehicle = await this.vehicleService.unassignVehicleFromRun(req.params.id);
-      res.json(vehicle);
+      res.json(createSuccessResponse(vehicle));
     } catch (error) {
       res.status(500).json({ message: 'Error unassigning vehicle from run', error });
     }
@@ -93,7 +117,7 @@ export class VehicleController {
   async getAvailableVehicles(req: Request, res: Response): Promise<void> {
     try {
       const vehicles = await this.vehicleService.getAvailableVehicles();
-      res.json(vehicles);
+      res.json(createSuccessResponse(vehicles));
     } catch (error) {
       res.status(500).json({ message: 'Error getting available vehicles', error });
     }
@@ -111,7 +135,7 @@ export class VehicleController {
   async getMaintenanceHistory(req: Request, res: Response): Promise<void> {
     try {
       const history = await this.vehicleService.getMaintenanceHistory(req.params.id);
-      res.json(history);
+      res.json(createSuccessResponse(history));
     } catch (error) {
       res.status(500).json({ message: 'Error getting maintenance history', error });
     }
@@ -123,7 +147,7 @@ export class VehicleController {
         req.params.id,
         req.body as TelemetryRecordDto
       );
-      res.status(201).json(record);
+      res.status(201).json(createSuccessResponse(record));
     } catch (error) {
       res.status(500).json({ message: 'Error adding telemetry record', error });
     }
@@ -136,7 +160,7 @@ export class VehicleController {
         res.status(404).json({ message: 'Telemetry not found' });
         return;
       }
-      res.json(record);
+      res.json(createSuccessResponse(record));
     } catch (error) {
       res.status(500).json({ message: 'Error getting latest telemetry', error });
     }


### PR DESCRIPTION
## Summary
- wrap controller success data using `createSuccessResponse` helpers
- add `createPaginatedResponse` for paginated lists
- re-export response helpers from `@send/shared`
- update related unit tests

## Testing
- `pnpm test` *(fails: Tasks not run because their dependencies failed)*

------
https://chatgpt.com/codex/tasks/task_e_684486185da4833393942cd386a14556