### PR TITLE
Add CORS origin env to services

### DIFF
--- a/packages/admin-service/README.md
+++ b/packages/admin-service/README.md
@@ -32,6 +32,7 @@ pnpm dev
 ## Environment Variables
 
 - `PORT` - Server port (default: 3012)
+- `FRONTEND_URL` - allowed origin for CORS requests
 
 ## License
 

--- a/packages/admin-service/src/app.ts
+++ b/packages/admin-service/src/app.ts
@@ -29,7 +29,7 @@ const controller = new AdminController(
 const app = express();
 app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
-app.use(cors());
+app.use(cors({ origin: process.env.FRONTEND_URL }));
 app.use(compression());
 app.use(express.json());
 app.use(rateLimit("admin-service"));

--- a/packages/api-gateway/README.md
+++ b/packages/api-gateway/README.md
@@ -17,6 +17,7 @@ traffic to the underlying services and enforces authentication using the shared
 - `LOG_LEVEL` - Log verbosity (default: `info`)
 - `PROXY_RETRY_ATTEMPTS` - Number of retry attempts for proxied requests (default: `3`)
 - `PROXY_RETRY_DELAY_MS` - Delay between retries in milliseconds (default: `100`)
+- `FRONTEND_URL` - allowed origin for CORS requests
  main
 
 ## Development

--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import cors from "cors";
 import { createProxyMiddleware } from "http-proxy-middleware";
 import { authenticate } from "@send/shared";
 import { rateLimit } from "@send/shared/security/middleware";
@@ -64,6 +65,7 @@ const app = express();
 app.use(express.json());
 app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
+app.use(cors({ origin: process.env.FRONTEND_URL }));
 app.use(rateLimit("api-gateway"));
 
 

--- a/packages/document-service/README.md
+++ b/packages/document-service/README.md
@@ -42,6 +42,7 @@ pnpm test
 - `RABBITMQ_URL` – RabbitMQ connection URL
 - `LOG_LEVEL` – Log level (default: info)
 - `LOG_FILE` – Optional log file path
+- `FRONTEND_URL` - allowed origin for CORS requests
 
 ## API Endpoints
 

--- a/packages/document-service/src/app.ts
+++ b/packages/document-service/src/app.ts
@@ -51,7 +51,7 @@ const healthCheckService = new HealthCheckService(
 // Middleware
 app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
-app.use(cors());
+app.use(cors({ origin: process.env.FRONTEND_URL }));
 app.use(compression());
 app.use(express.json());
 app.use(rateLimit("document-service"));

--- a/packages/driver-service/README.md
+++ b/packages/driver-service/README.md
@@ -29,3 +29,7 @@ This service manages driver data and publishes driver events.
   ]
   ```
 - `/docs` - API documentation
+
+## Environment Variables
+
+- `FRONTEND_URL` - allowed origin for CORS requests

--- a/packages/driver-service/src/index.ts
+++ b/packages/driver-service/src/index.ts
@@ -49,7 +49,7 @@ const driverController = new DriverController(driverService);
 // Middleware
 app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
-app.use(cors());
+app.use(cors({ origin: process.env.FRONTEND_URL }));
 app.use(helmet());
 app.use(compression());
 app.use(express.json());

--- a/packages/incident-service/README.md
+++ b/packages/incident-service/README.md
@@ -34,6 +34,7 @@ pnpm dev
 ## Environment Variables
 
 - `PORT` - Server port (default: 3010)
+- `FRONTEND_URL` - allowed origin for CORS requests
 
 ## License
 

--- a/packages/incident-service/src/app.ts
+++ b/packages/incident-service/src/app.ts
@@ -48,7 +48,7 @@ const incidentController = new IncidentController(incidentService);
 const app = express();
 app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
-app.use(cors());
+app.use(cors({ origin: process.env.FRONTEND_URL }));
 app.use(compression());
 app.use(express.json());
 app.use(rateLimit("incident-service"));

--- a/packages/invoicing-service/README.md
+++ b/packages/invoicing-service/README.md
@@ -32,6 +32,7 @@ pnpm dev
 ## Environment Variables
 
 - `PORT` - Server port (default: 3011)
+- `FRONTEND_URL` - allowed origin for CORS requests
 
 ## License
 

--- a/packages/invoicing-service/src/app.ts
+++ b/packages/invoicing-service/src/app.ts
@@ -33,7 +33,7 @@ const invoiceController = new InvoiceController(invoiceService);
 const app = express();
 app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
-app.use(cors());
+app.use(cors({ origin: process.env.FRONTEND_URL }));
 app.use(compression());
 app.use(express.json());
 app.use(rateLimit("invoicing-service"));

--- a/packages/run-service/README.md
+++ b/packages/run-service/README.md
@@ -73,6 +73,7 @@ pnpm test
 - `RABBITMQ_EXCHANGE` - RabbitMQ exchange name
 - `RABBITMQ_QUEUE` - RabbitMQ queue name
 - `MAPS_API_KEY` - Google Maps API key
+- `FRONTEND_URL` - allowed origin for CORS requests
 
 ## Architecture
 

--- a/packages/run-service/src/app.ts
+++ b/packages/run-service/src/app.ts
@@ -43,7 +43,7 @@ rabbitMQ.connect().catch(error => logger.error('RabbitMQ connection error', erro
 // Middleware
 app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
-app.use(cors());
+app.use(cors({ origin: process.env.FRONTEND_URL }));
 app.use(compression());
 app.use(express.json());
 app.use(rateLimit("run-service"));

--- a/packages/student-service/README.md
+++ b/packages/student-service/README.md
@@ -32,6 +32,7 @@ The Student Service manages student profiles, guardians and attendance within th
 - `DATABASE_URL` – PostgreSQL connection string used by Prisma
 - `JWT_SECRET` – secret key for verifying authentication tokens
 - `RABBITMQ_URL` – RabbitMQ connection URL
+- `FRONTEND_URL` - allowed origin for CORS requests
 
 ## Example API Routes
 

--- a/packages/student-service/src/app.ts
+++ b/packages/student-service/src/app.ts
@@ -18,7 +18,7 @@ const app = express();
 // Middleware
 app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
-app.use(cors());
+app.use(cors({ origin: process.env.FRONTEND_URL }));
 app.use(compression());
 app.use(express.json());
 app.use(rateLimit("student-service"));

--- a/packages/tracking-service/README.md
+++ b/packages/tracking-service/README.md
@@ -107,6 +107,7 @@ pnpm test:coverage
 - `DATABASE_URL` - PostgreSQL connection string
 - `RABBITMQ_URL` - RabbitMQ connection string
 - `JWT_SECRET` - JWT secret for authentication
+- `FRONTEND_URL` - allowed origin for CORS requests
 
 ## Dependencies
 

--- a/packages/tracking-service/src/index.ts
+++ b/packages/tracking-service/src/index.ts
@@ -72,7 +72,7 @@ const trackingController = new TrackingController(trackingService);
 // Middleware
 app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
-app.use(cors());
+app.use(cors({ origin: process.env.FRONTEND_URL }));
 app.use(helmet());
 app.use(compression());
 app.use(express.json());

--- a/packages/user-service/README.md
+++ b/packages/user-service/README.md
@@ -76,6 +76,7 @@ The User Service is a microservice responsible for user management in the SEND T
 - `JWT_EXPIRES_IN` - JWT token expiration time
 - `RABBITMQ_URL` - RabbitMQ connection URL
 - `RABBITMQ_EXCHANGE` - RabbitMQ exchange name
+- `FRONTEND_URL` - allowed origin for CORS requests
 
 ## Event Bus
 

--- a/packages/user-service/src/app.ts
+++ b/packages/user-service/src/app.ts
@@ -24,7 +24,7 @@ const monitoringService = MonitoringService.getInstance();
 // Middleware
 app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
-app.use(cors());
+app.use(cors({ origin: process.env.FRONTEND_URL }));
 app.use(compression() as unknown as express.RequestHandler);
 app.use(express.json());
 app.use(rateLimit("user-service"));

--- a/packages/user-service/src/index.ts
+++ b/packages/user-service/src/index.ts
@@ -17,7 +17,7 @@ const logger = new LoggerService({ serviceName: 'user-service' });
 
 // Middleware
 app.use(helmet());
-app.use(cors());
+app.use(cors({ origin: process.env.FRONTEND_URL }));
 app.use(express.json());
 app.use((req, res, next) => {
   logger.info('Incoming request', { method: req.method, url: req.url, ip: req.ip });

--- a/packages/vehicle-service/README.md
+++ b/packages/vehicle-service/README.md
@@ -186,6 +186,7 @@ Environment variables:
 - `DATABASE_URL`: Database connection string
 - `JWT_SECRET`: JWT signing secret
 - `RABBITMQ_URL`: RabbitMQ connection URL
+- `FRONTEND_URL` - allowed origin for CORS requests
 - `API_KEY`: API key for service authentication
 
 ## Contributing

--- a/packages/vehicle-service/src/index.ts
+++ b/packages/vehicle-service/src/index.ts
@@ -41,7 +41,7 @@ const vehicleController = new VehicleController(vehicleService);
 // Middleware
 app.use(securityHeadersMiddleware());
 app.use(ipRateLimitMiddleware());
-app.use(cors());
+app.use(cors({ origin: process.env.FRONTEND_URL }));
 app.use(helmet());
 app.use(compression());
 app.use(express.json());


### PR DESCRIPTION
## Summary
- use configured frontend origin for CORS in all services
- document `FRONTEND_URL` env var in each service README

## Testing
- `pnpm test` *(fails: Start by importing your Prisma Client ...)*

------
https://chatgpt.com/codex/tasks/task_e_6868287bc1088333a1ed606b5f71a77d