### PR TITLE
Implement refresh tokens in user service

### DIFF
--- a/packages/user-service/README.md
+++ b/packages/user-service/README.md
@@ -16,7 +16,7 @@ The User Service is a microservice responsible for user management in the SEND T
 ### Authentication
 - `POST /api/auth/login` - User login
 - `POST /api/auth/register` - User registration
-- `POST /api/auth/refresh-token` - Refresh JWT token
+- `POST /api/auth/refresh` - Refresh JWT using a refresh token
 - `POST /api/users/password/reset-request` - Request password reset
 - `POST /api/users/password/reset` - Reset password
 
@@ -76,6 +76,14 @@ The User Service is a microservice responsible for user management in the SEND T
 - `JWT_EXPIRES_IN` - JWT token expiration time
 - `RABBITMQ_URL` - RabbitMQ connection URL
 - `RABBITMQ_EXCHANGE` - RabbitMQ exchange name
+
+## Token Lifecycle
+
+After a successful login the service returns both a short-lived JWT and a long lived refresh token.
+The refresh token expires after seven days and should be stored in an HTTP only
+cookie when used from a browser. Clients call `POST /api/auth/refresh` with the
+refresh token to obtain a new JWT and rotated refresh token. The access token is
+sent in the response body and can be used in the `Authorization` header.
 
 ## Event Bus
 

--- a/packages/user-service/prisma/schema.prisma
+++ b/packages/user-service/prisma/schema.prisma
@@ -39,6 +39,7 @@ model User {
   pa       Pa?
   guardian Guardian?
   passwordResetTokens PasswordResetToken[]
+  refreshTokens      RefreshToken[]
 
   @@map("users")
 }
@@ -105,4 +106,15 @@ model PasswordResetToken {
   createdAt DateTime @default(now())
 
   @@map("password_reset_tokens")
+}
+
+model RefreshToken {
+  id        String   @id @default(uuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id])
+  token     String   @unique
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+
+  @@map("refresh_tokens")
 }

--- a/packages/user-service/src/api/routes/auth.routes.ts
+++ b/packages/user-service/src/api/routes/auth.routes.ts
@@ -40,16 +40,17 @@ router.post(
   }
 );
 
-router.post('/refresh-token', async (req, res, next) => {
+router.post('/refresh', async (req, res, next) => {
   try {
-    const { token } = req.body;
-    if (!token) {
-      throw new AppError(400, 'Token is required');
+    const { refreshToken } = req.body;
+    if (!refreshToken) {
+      throw new AppError(400, 'Refresh token is required');
     }
 
-    const user = await authService.validateToken(token);
-    const newToken = authService.generateToken(user);
-    res.json(createSuccessResponse({ user, token: newToken }));
+    const user = await authService.validateRefreshToken(refreshToken);
+    const token = authService.generateToken(user);
+    const newRefresh = await authService.generateRefreshToken(user);
+    res.json(createSuccessResponse({ user, token, refreshToken: newRefresh }));
   } catch (error) {
     next(error);
   }

--- a/packages/user-service/src/data/models/refreshToken.model.ts
+++ b/packages/user-service/src/data/models/refreshToken.model.ts
@@ -1,0 +1,22 @@
+import { PrismaClient } from '../../../prisma/generated/client';
+
+const prisma = new PrismaClient();
+
+export const RefreshTokenModel = {
+  async create(data: { userId: string; token: string; expiresAt: Date }) {
+    return prisma.refreshToken.create({ data });
+  },
+
+  async findValid(token: string) {
+    return prisma.refreshToken.findFirst({
+      where: {
+        token,
+        expiresAt: { gt: new Date() }
+      }
+    });
+  },
+
+  async delete(id: string) {
+    return prisma.refreshToken.delete({ where: { id } });
+  }
+};


### PR DESCRIPTION
## Summary
- support refresh tokens in the user service
- expose `/api/auth/refresh` endpoint
- document token lifecycle and updated endpoints

## Testing
- `pnpm --filter user-service test` *(fails: cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_6868287d46a48333b385834941ca056a