### PR TITLE
Fix run-service build and tests

### DIFF
--- a/packages/run-service/package.json
+++ b/packages/run-service/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/index.js",
     "dev": "nodemon src/index.ts",
     "build": "tsc",
-    "test": "jest --config jest.config.js --tsconfig tsconfig.test.json",
+    "test": "jest --config jest.config.js",
     "lint": "eslint src/**/*.ts",
     "format": "prettier --write \"src/**/*.ts\"",
     "prisma:generate": "prisma generate",

--- a/packages/run-service/src/__tests__/controllers/run.controller.test.ts
+++ b/packages/run-service/src/__tests__/controllers/run.controller.test.ts
@@ -6,6 +6,7 @@ import { RouteService } from '../../infra/services/route.service';
 import { ScheduleService } from '../../infra/services/schedule.service';
 import { Run, RunStatus, RunType, ScheduleType } from '@shared/types/run';
 import { PrismaClient } from '@prisma/client';
+import { createSuccessResponse } from '@send/shared';
 
 // Event type constants
 const RUN_CREATED = 'RUN_CREATED';
@@ -113,7 +114,7 @@ describe('RunController', () => {
       mockReq.body = runData;
       mockRunModel.create.mockResolvedValue(createdRun);
 
-      await controller.createRun(mockReq as Request, mockRes as Response);
+      await controller.createRun(mockReq as Request, mockRes as Response, jest.fn());
 
       expect(mockRunModel.create).toHaveBeenCalledWith(expect.objectContaining(runData));
       expect(mockPublishRunEvent).toHaveBeenCalledWith(RUN_CREATED, createdRun);
@@ -155,11 +156,13 @@ describe('RunController', () => {
       mockReq.body = updateData;
       mockRunModel.update.mockResolvedValue(updatedRun);
 
-      await controller.updateRun(mockReq as Request, mockRes as Response);
+      await controller.updateRun(mockReq as Request, mockRes as Response, jest.fn());
 
       expect(mockRunModel.update).toHaveBeenCalledWith(runId, updateData);
       expect(mockPublishRunEvent).toHaveBeenCalledWith(RUN_UPDATED, updatedRun);
-      expect(mockRes.json).toHaveBeenCalledWith({ run: updatedRun });
+      expect(mockRes.json).toHaveBeenCalledWith(
+        createSuccessResponse({ run: updatedRun })
+      );
     });
   });
 
@@ -190,11 +193,13 @@ describe('RunController', () => {
       mockReq.params = { id: runId };
       mockRunModel.update.mockResolvedValue(cancelledRun);
 
-      await controller.cancelRun(mockReq as Request, mockRes as Response);
+      await controller.cancelRun(mockReq as Request, mockRes as Response, jest.fn());
 
       expect(mockRunModel.update).toHaveBeenCalledWith(runId, { status: RunStatus.CANCELLED });
       expect(mockPublishRunEvent).toHaveBeenCalledWith(RUN_CANCELLED, cancelledRun);
-      expect(mockRes.json).toHaveBeenCalledWith({ run: cancelledRun });
+      expect(mockRes.json).toHaveBeenCalledWith(
+        createSuccessResponse({ run: cancelledRun })
+      );
     });
   });
 
@@ -226,14 +231,16 @@ describe('RunController', () => {
       mockReq.params = { id: runId };
       mockRunModel.update.mockResolvedValue(completedRun);
 
-      await controller.completeRun(mockReq as Request, mockRes as Response);
+      await controller.completeRun(mockReq as Request, mockRes as Response, jest.fn());
 
       expect(mockRunModel.update).toHaveBeenCalledWith(runId, { 
         status: RunStatus.COMPLETED,
         endTime: expect.any(Date)
       });
       expect(mockPublishRunEvent).toHaveBeenCalledWith(RUN_COMPLETED, completedRun);
-      expect(mockRes.json).toHaveBeenCalledWith({ run: completedRun });
+      expect(mockRes.json).toHaveBeenCalledWith(
+        createSuccessResponse({ run: completedRun })
+      );
     });
   });
 }); 

--- a/packages/run-service/src/__tests__/infra/messaging/rabbitmq.test.ts
+++ b/packages/run-service/src/__tests__/infra/messaging/rabbitmq.test.ts
@@ -84,7 +84,11 @@ describe('RabbitMQService', () => {
         'run-events',
         'RUN_CREATED',
         expect.any(Buffer),
-        { persistent: true }
+        expect.objectContaining({
+          persistent: true,
+          contentType: 'application/json',
+          timestamp: expect.any(Number)
+        })
       );
     });
 
@@ -128,7 +132,11 @@ describe('RabbitMQService', () => {
         'run-events',
         'notification',
         expect.any(Buffer),
-        { persistent: true }
+        expect.objectContaining({
+          persistent: true,
+          contentType: 'application/json',
+          timestamp: expect.any(Number)
+        })
       );
     });
 
@@ -153,7 +161,11 @@ describe('RabbitMQService', () => {
 
       expect(mockChannel.consume).toHaveBeenCalledWith(
         'run-notifications',
-        expect.any(Function)
+        expect.any(Function),
+        expect.objectContaining({
+          noAck: false,
+          consumerTag: 'run-notifications-consumer'
+        })
       );
     });
 

--- a/packages/run-service/src/__tests__/setup.ts
+++ b/packages/run-service/src/__tests__/setup.ts
@@ -1,6 +1,6 @@
-import { PrismaClient } from '@send/shared';
+import { databaseService } from '@send/shared';
 
-const prisma = new PrismaClient();
+const prisma = databaseService.getPrismaClient();
 process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/test';
 
 beforeAll(async () => {

--- a/packages/run-service/src/api/controllers/run.controller.ts
+++ b/packages/run-service/src/api/controllers/run.controller.ts
@@ -7,16 +7,6 @@ import { ScheduleService } from '../../infra/services/schedule.service';
 import { AppError } from '@shared/errors';
 import { createSuccessResponse } from '@send/shared';
 
-declare global {
-  namespace Express {
-    interface Request {
-      user?: {
-        id: string;
-        role: string;
-      };
-    }
-  }
-}
 
 export class RunController {
   constructor(

--- a/packages/shared/src/db/database.service.ts
+++ b/packages/shared/src/db/database.service.ts
@@ -22,7 +22,7 @@ export class DatabaseService {
     this.prisma.$connect().then(() => {
       incrementConnections();
       logger.info('Database connected successfully');
-    }).catch((error) => {
+    }).catch((error: unknown) => {
       incrementErrors();
       logger.error('Failed to connect to database:', error);
     });
@@ -30,7 +30,7 @@ export class DatabaseService {
     this.prisma.$disconnect().then(() => {
       incrementDisconnections();
       logger.info('Database disconnected successfully');
-    }).catch((error) => {
+    }).catch((error: unknown) => {
       incrementErrors();
       logger.error('Failed to disconnect from database:', error);
     });

--- a/test/prisma-client.ts
+++ b/test/prisma-client.ts
@@ -1,5 +1,11 @@
 export class PrismaClient {
   [key: string]: any
+  async $connect() {
+    /* no-op for tests */
+  }
+  async $disconnect() {
+    /* no-op for tests */
+  }
 }
 
 // Enum stubs used in tests


### PR DESCRIPTION
## Summary
- remove custom Request user type for compatibility
- export databaseService in tests
- update rabbitmq tests expectations
- adjust controller tests to use createSuccessResponse
- stub PrismaClient methods for tests
- clean up test script

## Testing
- `pnpm build`
- `pnpm test --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687f73b4c72083339d073c4e7f51239a